### PR TITLE
feat: bootstrap monorepo structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Python
+__pycache__/
+*.pyc
+.venv/
+.mypy_cache/
+.pytest_cache/
+
+# Node / Angular
+node_modules/
+dist/
+.angular/
+
+# Env files
+.env
+.env.*
+
+# OS / editor
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+
+# Docker
+*.log

--- a/TODO.md
+++ b/TODO.md
@@ -3,11 +3,11 @@
 Below is a structured checklist you can turn into issues. Nothing is marked done yet.
 
 ## Project & Infra
-- [ ] Initialize monorepo with `backend/`, `frontend/`, `infra/`.
-- [ ] Add `docker-compose.yml` for API, frontend, Postgres.
-- [ ] Add backend `.env.example` (DATABASE_URL, SECRET_KEY, STRIPE_SECRET_KEY, SMTP_*, FRONTEND_ORIGIN).
-- [ ] Add frontend `.env.example` (API_BASE_URL, STRIPE_PUBLISHABLE_KEY, APP_ENV).
-- [ ] Add `.gitignore` for Python, Node, env files, build artifacts.
+- [x] Initialize monorepo with `backend/`, `frontend/`, `infra/`.
+- [x] Add `docker-compose.yml` for API, frontend, Postgres.
+- [x] Add backend `.env.example` (DATABASE_URL, SECRET_KEY, STRIPE_SECRET_KEY, SMTP_*, FRONTEND_ORIGIN).
+- [x] Add frontend `.env.example` (API_BASE_URL, STRIPE_PUBLISHABLE_KEY, APP_ENV).
+- [x] Add `.gitignore` for Python, Node, env files, build artifacts.
 - [ ] GitHub Actions for backend (lint, tests, type-checks).
 - [ ] GitHub Actions for frontend (lint, tests, build).
 - [ ] CONTRIBUTING.md with branching, commit style, runbook.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+# Backend
+
+FastAPI + PostgreSQL service. Wire configuration via `.env` (see `.env.example`) and run migrations via Alembic.
+
+Quick start (placeholder):
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+alembic upgrade head
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,10 @@
+# Frontend
+
+Angular 18 storefront/admin UI. Configure API endpoint and Stripe keys via `.env.example`.
+
+Quick start (placeholder):
+```bash
+npm install
+cp .env.example .env
+npm start
+```

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: adrianaart
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  backend:
+    build:
+      context: ../
+      dockerfile: backend/Dockerfile
+    env_file:
+      - ../backend/.env.example
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build:
+      context: ../
+      dockerfile: frontend/Dockerfile
+    env_file:
+      - ../frontend/.env.example
+    depends_on:
+      - backend
+    ports:
+      - "4200:4200"
+
+volumes:
+  db_data:


### PR DESCRIPTION
**Summary**
- Bootstrap the monorepo layout with backend, frontend, and infra directories plus starter docs.
- Add docker-compose skeleton for API, frontend, and Postgres services.
- Provide baseline .env examples and .gitignore for Python/Node projects.

**Changes**
- Added .gitignore, backend/frontend placeholders with README and env examples.
- Added infra/docker-compose.yml with db/backend/frontend services and persistent volume.
- Updated TODO.md to mark the initial infra tasks as completed.

**Testing**
- Not applicable (structure/docs only).

**Risk & Impact**
- Low; no runtime code.

**Related TODO items**
- [x] Initialize monorepo with `backend/`, `frontend/`, `infra/`.
- [x] Add `docker-compose.yml` for API, frontend, Postgres.
- [x] Add backend `.env.example` (DATABASE_URL, SECRET_KEY, STRIPE_SECRET_KEY, SMTP_*, FRONTEND_ORIGIN).
- [x] Add frontend `.env.example` (API_BASE_URL, STRIPE_PUBLISHABLE_KEY, APP_ENV).
- [x] Add `.gitignore` for Python, Node, env files, build artifacts.
