### PR TITLE
chore: add contributing and architecture docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,69 @@
+# Architecture Overview
+
+AdrianaArt is a monorepo with a FastAPI backend, Angular frontend, and lightweight infra for local/dev deployments. The stack favors clear boundaries between HTTP/API, domain logic, persistence, and presentation.
+
+## Monorepo layout
+
+- `backend/`: FastAPI app, domain models, services, migrations, tests.
+- `frontend/`: Angular 18 storefront and admin UI with shared design tokens/components.
+- `infra/`: Docker Compose for local stack (Postgres, backend, frontend) and future deployment tooling.
+
+## Backend (FastAPI + PostgreSQL)
+
+- **Entrypoint**: `app.main:app` mounts a versioned `/api/v1` router.
+- **Configuration**: `pydantic-settings` reads environment (`DATABASE_URL`, `SECRET_KEY`, `STRIPE_SECRET_KEY`, `SMTP_*`, `FRONTEND_ORIGIN`).
+- **Persistence**: SQLAlchemy engine/session factory; Alembic migrations track schema.
+- **Auth**:
+  - Users stored with salted password hashes.
+  - JWT-based sessions (access + refresh) issued at login/refresh; stored in HTTP-only cookies.
+  - Dependency-based guards for authenticated + role-gated routes (e.g., admin).
+- **Domain slices**:
+  - Catalog: categories, products, product images/variants; search/pagination filters.
+  - Cart/checkout: carts keyed by user or guest session; merges guest cart on login; stock validated on write.
+  - Orders/payments: order builder snapshots prices; Stripe PaymentIntent for payments; webhooks reconcile status.
+  - Content: editable content blocks for hero/about/faq/shipping/care.
+  - Email: SMTP-backed service for transactional emails (order confirmation, password reset).
+- **Cross-cutting**: structured logging with request IDs, CORS config, rate limiting on auth endpoints, file-type/size validation for uploads.
+- **Testing**: pytest suite with factory helpers and integration tests against a temporary Postgres (e.g., testcontainers).
+
+### Backend request/data flow (example: checkout)
+
+1. Frontend collects cart + address and calls `POST /api/v1/checkout` (or order builder).
+2. FastAPI handler pulls user/guest session, validates stock via services, builds an Order snapshot, and creates a Stripe PaymentIntent.
+3. PaymentIntent client secret returned to frontend; frontend confirms payment via Stripe JS.
+4. Stripe webhook hits `/api/v1/webhooks/stripe`, verifying signature; order status updated (Paid/Failed).
+5. Background task (or immediate) triggers order confirmation email.
+
+## Frontend (Angular 18 + Tailwind)
+
+- **Shell**: App component provides layout, header/footer, and responsive navigation.
+- **Routing**: Lazy-loaded feature routes for catalog, product detail, cart/checkout, auth/account, and admin.
+- **State/data**:
+  - Services using Angular `HttpClient` for API calls; interceptors for auth cookies, loading/error handling.
+  - Signals/observables for client state (cart, user session, feature flags).
+  - LocalStorage used to persist guest carts/session IDs and merge with server carts after login.
+- **UI**:
+  - Shared primitives (button/input/card/modal/toast) with Tailwind design tokens.
+  - Storefront components for hero, featured grid, product cards/detail, filters, and search.
+  - Admin area with guarded routes and tables/forms for products, orders, content, and users.
+- **Error handling**: global error boundary/route guard surfaces toasts, friendly fallback pages, and retries where safe.
+
+### Frontend -> Backend flows
+
+- **Browsing**: `/products` with pagination/filter params; product detail fetched by slug; images served from backend/S3-compatible storage.
+- **Cart**: guest cart stored locally and synced via `/cart`; server validates stock on add/update/delete.
+- **Auth**: login/register/reset forms call auth endpoints; refresh tokens handled via interceptor; logout clears cookies + local state.
+- **Admin**: guarded routes call admin-prefixed APIs for product/order/content CRUD; uploads validated client-side before send.
+
+## Infra & CI/CD
+
+- **Local dev**: `docker compose up --build` runs Postgres, backend, and frontend with hot reload (once Dockerfiles exist).
+- **Environment parity**: `.env.example` files document required settings for each service.
+- **CI (existing)**: GitHub Actions run backend lint/tests/type-check and frontend lint/tests/build.
+- **CI (planned)**: deployment/release workflow to build/push containers and publish artifacts once runtime code lands.
+
+## Observability & security (planned)
+
+- Structured JSON logs with request IDs for traceability.
+- Basic metrics (request latency/error rate) via ASGI middleware; health/readiness endpoints for Kubernetes/compose.
+- Input validation via Pydantic schemas; strict CORS for production origins; rate limiting on auth-sensitive routes; upload validation to prevent malicious files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to AdrianaArt
+
+Thanks for helping build the AdrianaArt storefront and admin suite. This monorepo will house the FastAPI backend, Angular frontend, and infra tooling. Keep contributions small, well-tested, and documented so the project stays easy to evolve.
+
+## Workflow
+
+- Default branch: `main`. Create topic branches from an up-to-date `main`.
+- Branch names: `feat/<slug>`, `fix/<slug>`, or `chore/<slug>` (e.g., `feat/auth-api`, `chore/ci-tweaks`).
+- Commits: Conventional style (`feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`).
+- Pull requests: Keep scope tight; include summary, key changes, tests run, and risks/impact. Update `TODO.md` when you complete or add work items.
+- Keep commits/PRs in the same language/service wherever possible (backend vs frontend vs infra).
+
+## Local setup (until scaffolding lands)
+
+Prereqs: Python 3.11+, Node.js 20 LTS, Docker + docker-compose.
+
+### Backend (FastAPI)
+
+```
+cd backend
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+
+# Configure secrets
+cp .env.example .env  # or create .env with DATABASE_URL, SECRET_KEY, STRIPE_SECRET_KEY, SMTP_*, FRONTEND_ORIGIN
+
+# Run migrations and start API
+alembic upgrade head
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+### Frontend (Angular)
+
+```
+cd frontend
+npm install
+cp .env.example .env  # set API_BASE_URL, STRIPE_PUBLISHABLE_KEY, APP_ENV
+npm start
+```
+
+### Docker stack
+
+```
+cd infra
+docker compose up --build
+```
+
+## Quality gates
+
+- **Backend**: `ruff check .`, `black .`, `isort .`, `mypy .`, `pytest`.
+- **Frontend**: `npm run lint`, `npm test`, `npm run build`.
+- **Infra**: `docker compose config` to validate compose file.
+- Run relevant checks before opening a PR; prefer fixing lint/type issues in the same branch.
+
+## Runbook (common tasks)
+
+- **Sync main**: `git checkout main && git pull --rebase origin main`.
+- **Create branch**: `git checkout -b feat/<slug>` from `main`.
+- **Update backlog**: Mark finished items in `TODO.md`; append concise follow-ups when discovered.
+- **Reset local DB** (Docker): `docker compose down -v && docker compose up --build`.
+- **Apply migrations**: `alembic upgrade head` (once migrations exist).
+- **Seed dev data**: add or run a seed script under `backend/` once available to speed up UI testing.
+- **Logs**: `docker compose logs -f backend` and `docker compose logs -f frontend` for live debugging.
+
+## Pull request expectations
+
+- Include tests or rationale when skipping them.
+- Update docs/config when behavior changes (README, `.env.example`, `ARCHITECTURE.md`, `TODO.md`).
+- Keep PRs reviewable; split into smaller PRs rather than mixing backend, frontend, and infra changes.
+- Note any breaking changes, data migrations, or manual steps in the PR description.

--- a/TODO.md
+++ b/TODO.md
@@ -10,8 +10,8 @@ Below is a structured checklist you can turn into issues. Nothing is marked done
 - [x] Add `.gitignore` for Python, Node, env files, build artifacts.
 - [x] GitHub Actions for backend (lint, tests, type-checks).
 - [x] GitHub Actions for frontend (lint, tests, build).
-- [ ] CONTRIBUTING.md with branching, commit style, runbook.
-- [ ] ARCHITECTURE.md with high-level design and data flow.
+- [x] CONTRIBUTING.md with branching, commit style, runbook.
+- [x] ARCHITECTURE.md with high-level design and data flow.
 - [ ] CI: add deployment/release job (e.g., container build + push) once runtime code lands.
 
 ## Backend – Core & Auth


### PR DESCRIPTION
**Summary**
- Add contributor guide covering branching, commits, tests, and runbook steps for the monorepo.
- Document the intended architecture for backend, frontend, and infra with key data flows.

**Changes**
- Add `CONTRIBUTING.md` with workflow, quality gates, and common runbook actions.
- Add `ARCHITECTURE.md` describing system components, data flow, and planned observability/security.
- Update `TODO.md` to mark the documentation tasks complete.

**Testing**
- Not run (docs only).

**Risk & Impact**
- Low; documentation-only changes.

**Related TODO items**
- [x] CONTRIBUTING.md with branching, commit style, runbook.
- [x] ARCHITECTURE.md with high-level design and data flow.