### PR TITLE
feat: scaffold backend api and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Optional tag for images (defaults to git tag or commit SHA)"
+        required: false
+        type: string
+  push:
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    name: Build and push containers
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute image metadata
+        id: meta
+        run: |
+          repo="$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')"
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            tag="${{ github.event.inputs.tag }}"
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            tag="${GITHUB_REF#refs/tags/}"
+          else
+            tag="${GITHUB_SHA::7}"
+          fi
+          {
+            echo "prefix=${{ env.REGISTRY }}/${repo}"
+            echo "tag=${tag}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend image
+        if: hashFiles('backend/Dockerfile') != ''
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: backend/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.prefix }}/backend:${{ steps.meta.outputs.tag }}
+            ${{ steps.meta.outputs.prefix }}/backend:latest
+          cache-from: type=registry,ref=${{ steps.meta.outputs.prefix }}/backend:latest
+          cache-to: type=inline
+
+      - name: Build and push frontend image
+        if: hashFiles('frontend/Dockerfile') != ''
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: frontend/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.prefix }}/frontend:${{ steps.meta.outputs.tag }}
+            ${{ steps.meta.outputs.prefix }}/frontend:latest
+          cache-from: type=registry,ref=${{ steps.meta.outputs.prefix }}/frontend:latest
+          cache-to: type=inline

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ dist/
 # Env files
 .env
 .env.*
+!.env.example
+!*/.env.example
 
 # OS / editor
 .DS_Store

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO / Roadmap
 
-Below is a structured checklist you can turn into issues. Nothing is marked done yet.
+Below is a structured checklist you can turn into issues.
 
 ## Project & Infra
 - [x] Initialize monorepo with `backend/`, `frontend/`, `infra/`.
@@ -12,11 +12,11 @@ Below is a structured checklist you can turn into issues. Nothing is marked done
 - [x] GitHub Actions for frontend (lint, tests, build).
 - [x] CONTRIBUTING.md with branching, commit style, runbook.
 - [x] ARCHITECTURE.md with high-level design and data flow.
-- [ ] CI: add deployment/release job (e.g., container build + push) once runtime code lands.
+- [x] CI: add deployment/release job (e.g., container build + push) once runtime code lands.
 
 ## Backend - Core & Auth
-- [ ] Scaffold FastAPI app with versioned `/api/v1` router.
-- [ ] Settings via `pydantic-settings`.
+- [x] Scaffold FastAPI app with versioned `/api/v1` router.
+- [x] Settings via `pydantic-settings`.
 - [ ] SQLAlchemy engine/session for Postgres.
 - [ ] User model + Alembic migration.
 - [ ] Password hashing/verification.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,14 @@
+APP_NAME=AdrianaArt API
+APP_VERSION=0.1.0
+ENVIRONMENT=local
+
+DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/adrianaart
+SECRET_KEY=dev-secret-key
+STRIPE_SECRET_KEY=sk_test_placeholder
+
+SMTP_HOST=localhost
+SMTP_PORT=1025
+SMTP_USERNAME=
+SMTP_PASSWORD=
+
+FRONTEND_ORIGIN=http://localhost:4200

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY backend/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,13 +1,20 @@
 # Backend
 
-FastAPI + PostgreSQL service. Wire configuration via `.env` (see `.env.example`) and run migrations via Alembic.
+FastAPI + PostgreSQL service with versioned API routing under `/api/v1`.
 
-Quick start (placeholder):
+## Quick start
+
 ```bash
 python -m venv .venv
-source .venv/bin/activate
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
-cp .env.example .env
-alembic upgrade head
+
+cp .env.example .env  # update DATABASE_URL, SECRET_KEY, STRIPE_SECRET_KEY, SMTP_*, FRONTEND_ORIGIN as needed
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+## Tests
+
+```bash
+pytest
 ```

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+# Makes the backend directory importable as a package.

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,1 @@
+# API package.

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,0 +1,3 @@
+from .routes import api_router
+
+__all__ = ["api_router"]

--- a/backend/app/api/v1/routes.py
+++ b/backend/app/api/v1/routes.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+api_router = APIRouter()
+
+
+@api_router.get("/health", tags=["health"])
+def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,0 +1,1 @@
+# Core configuration and shared utilities.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,32 @@
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables or a .env file."""
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", case_sensitive=False)
+
+    app_name: str = "AdrianaArt API"
+    app_version: str = "0.1.0"
+    environment: str = "local"
+
+    database_url: str = "postgresql+psycopg://postgres:postgres@localhost:5432/adrianaart"
+    secret_key: str = "dev-secret-key"
+    stripe_secret_key: str = "sk_test_placeholder"
+
+    smtp_host: str = "localhost"
+    smtp_port: int = 1025
+    smtp_username: str | None = None
+    smtp_password: str | None = None
+
+    frontend_origin: str = "http://localhost:4200"
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()
+
+
+settings = get_settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+
+from app.api.v1 import api_router
+from app.core.config import settings
+
+
+def get_application() -> FastAPI:
+    app = FastAPI(title=settings.app_name, version=settings.app_version)
+    app.include_router(api_router, prefix="/api/v1")
+    return app
+
+
+app = get_application()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.2
+uvicorn[standard]==0.29.0
+pydantic-settings==2.3.4
+httpx==0.27.0
+pytest==8.2.2

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_healthcheck() -> None:
+    response = client.get("/api/v1/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
**Summary**
- Add a release workflow that can build and push backend/frontend containers to GHCR on tag or manual dispatch.
- Scaffold FastAPI backend with versioned `/api/v1` router, health endpoint, and pydantic settings with `.env.example`.
- Provide backend Dockerfile, requirements, and a sanity test to keep CI green.

**Changes**
- Added `.github/workflows/release.yml` with GHCR login and build/push steps guarded by Dockerfile presence.
- Created backend app skeleton (FastAPI app, `/api/v1` router with healthcheck, settings module) plus Dockerfile and requirements.
- Added backend `.env.example`, updated README, and included a basic pytest for the health endpoint; TODO backlog updated accordingly.

**Testing**
- `cd backend && python3 -m pytest`

**Risk & Impact**
- Low: scaffolding and CI additions only; release workflow pushes to GHCR using `GITHUB_TOKEN` when run.

**Related TODO items**
- [x] CI: add deployment/release job (e.g., container build + push) once runtime code lands.
- [x] Scaffold FastAPI app with versioned `/api/v1` router.
- [x] Settings via `pydantic-settings`.