### PR TITLE
feat: add sqlalchemy setup and user migration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,8 +17,8 @@ Below is a structured checklist you can turn into issues.
 ## Backend - Core & Auth
 - [x] Scaffold FastAPI app with versioned `/api/v1` router.
 - [x] Settings via `pydantic-settings`.
-- [ ] SQLAlchemy engine/session for Postgres.
-- [ ] User model + Alembic migration.
+- [x] SQLAlchemy engine/session for Postgres.
+- [x] User model + Alembic migration.
 - [ ] Password hashing/verification.
 - [ ] Auth endpoints: register, login (access+refresh), refresh, logout.
 - [ ] JWT guard dependency + role guard for admin.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,7 +2,7 @@ APP_NAME=AdrianaArt API
 APP_VERSION=0.1.0
 ENVIRONMENT=local
 
-DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/adrianaart
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/adrianaart
 SECRET_KEY=dev-secret-key
 STRIPE_SECRET_KEY=sk_test_placeholder
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,5 +9,7 @@ COPY backend/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY backend/app ./app
+COPY backend/alembic ./alembic
+COPY backend/alembic.ini ./alembic.ini
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,6 +13,16 @@ cp .env.example .env  # update DATABASE_URL, SECRET_KEY, STRIPE_SECRET_KEY, SMTP
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
+## Database and migrations
+
+- Default `DATABASE_URL` uses async Postgres via `postgresql+asyncpg://...`.
+- Alembic is configured for async migrations:
+
+```bash
+alembic upgrade head
+alembic revision --autogenerate -m "describe change"  # after models exist
+```
+
 ## Tests
 
 ```bash

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,33 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+sqlalchemy.url = postgresql+asyncpg://postgres:postgres@localhost:5432/adrianaart
+
+[logging]
+level = INFO
+loggers = root,sqlalchemy,alembic
+handlers = console
+formatters = generic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,59 @@
+import asyncio
+import sys
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+sys.path.append(".")
+
+from app.core.config import settings  # noqa: E402
+from app.models import Base  # noqa: E402
+
+config = context.config
+fileConfig(config.config_file_name)
+config.set_main_option("sqlalchemy.url", settings.database_url)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = settings.database_url
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        future=True,
+    )
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/backend/alembic/versions/0001_create_users_table.py
+++ b/backend/alembic/versions/0001_create_users_table.py
@@ -1,0 +1,48 @@
+"""create users table
+
+Revision ID: 0001
+Revises:
+Create Date: 2024-10-05
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("hashed_password", sa.String(length=255), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column(
+            "role",
+            sa.Enum("customer", "admin", name="userrole"),
+            nullable=False,
+            server_default="customer",
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_table("users")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
     app_version: str = "0.1.0"
     environment: str = "local"
 
-    database_url: str = "postgresql+psycopg://postgres:postgres@localhost:5432/adrianaart"
+    database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/adrianaart"
     secret_key: str = "dev-secret-key"
     stripe_secret_key: str = "sk_test_placeholder"
 

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,0 +1,2 @@
+from app.db.base import Base  # noqa: F401
+from app.db.session import get_session  # noqa: F401

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -1,0 +1,26 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Base class for all ORM models."""
+
+
+class TimestampMixin:
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+def uuid_pk() -> Mapped[uuid.UUID]:
+    return mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,0 +1,14 @@
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import settings
+
+connect_args = {"check_same_thread": False} if settings.database_url.startswith("sqlite") else {}
+
+engine = create_async_engine(settings.database_url, future=True, echo=False, connect_args=connect_args)
+SessionLocal = async_sessionmaker(engine, expire_on_commit=False, autoflush=False, class_=AsyncSession)
+
+
+async def get_session() -> AsyncSession:
+    """FastAPI dependency to provide a database session."""
+    async with SessionLocal() as session:
+        yield session

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,4 @@
+from app.db.base import Base  # noqa: F401
+from app.models.user import User  # noqa: F401
+
+__all__ = ["Base", "User"]

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,33 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class UserRole(str, enum.Enum):
+    customer = "customer"
+    admin = "admin"
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
+    name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    role: Mapped[UserRole] = mapped_column(Enum(UserRole), nullable=False, server_default=UserRole.customer.value)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,9 @@
 fastapi==0.110.2
 uvicorn[standard]==0.29.0
 pydantic-settings==2.3.4
+sqlalchemy[asyncio]==2.0.31
+alembic==1.13.2
+asyncpg==0.29.0
+aiosqlite==0.20.0
 httpx==0.27.0
 pytest==8.2.2

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -1,0 +1,31 @@
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.db.base import Base
+from app.models.user import User, UserRole
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_user_model_persists_in_sqlite_memory() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with SessionLocal() as session:
+        user = User(email="alice@example.com", hashed_password="hashedpw", name="Alice")
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+
+        result = await session.execute(select(User).where(User.email == "alice@example.com"))
+        fetched = result.scalar_one()
+        assert fetched.id is not None
+        assert fetched.role == UserRole.customer


### PR DESCRIPTION
**Summary**
- Configure SQLAlchemy async engine/session with settings defaults and Docker support for migrations.
- Add User model with roles and timestamps plus initial Alembic migration and config.
- Add in-memory DB test, update README/TODO, and include alembic assets in the backend image.

**Changes**
- Added database session factory, base model utilities, and updated settings/.env for async Postgres URLs.
- Added `User` ORM model and Alembic setup with an initial migration; Dockerfile now copies alembic files.
- Added SQLite-backed persistence test for the user model, refreshed backend README, and marked backlog items done.

**Testing**
- `cd backend && . .venv/bin/activate && python -m pytest`

**Risk & Impact**
- Low: scaffolding only; no new endpoints or behavior changes yet.

**Related TODO items**
- [x] SQLAlchemy engine/session for Postgres.
- [x] User model + Alembic migration.