### PR TITLE
feat: add auth endpoints and jwt guard

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,10 +19,10 @@ Below is a structured checklist you can turn into issues.
 - [x] Settings via `pydantic-settings`.
 - [x] SQLAlchemy engine/session for Postgres.
 - [x] User model + Alembic migration.
-- [ ] Password hashing/verification.
-- [ ] Auth endpoints: register, login (access+refresh), refresh, logout.
-- [ ] JWT guard dependency + role guard for admin.
-- [ ] Tests for auth flows (register/login/refresh/invalid creds).
+- [x] Password hashing/verification.
+- [x] Auth endpoints: register, login (access+refresh), refresh, logout.
+- [x] JWT guard dependency + role guard for admin.
+- [x] Tests for auth flows (register/login/refresh/invalid creds).
 
 ## Backend - Catalog & Products
 - [ ] Category model + migration.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,6 +5,9 @@ ENVIRONMENT=local
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/adrianaart
 SECRET_KEY=dev-secret-key
 STRIPE_SECRET_KEY=sk_test_placeholder
+JWT_ALGORITHM=HS256
+ACCESS_TOKEN_EXP_MINUTES=30
+REFRESH_TOKEN_EXP_DAYS=7
 
 SMTP_HOST=localhost
 SMTP_PORT=1025

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,6 +13,11 @@ cp .env.example .env  # update DATABASE_URL, SECRET_KEY, STRIPE_SECRET_KEY, SMTP
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
+Key env vars:
+- `SECRET_KEY`, `JWT_ALGORITHM`, `ACCESS_TOKEN_EXP_MINUTES`, `REFRESH_TOKEN_EXP_DAYS`
+- `DATABASE_URL` (async driver, e.g., `postgresql+asyncpg://...`)
+- `SMTP_*`, `FRONTEND_ORIGIN`
+
 ## Database and migrations
 
 - Default `DATABASE_URL` uses async Postgres via `postgresql+asyncpg://...`.

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1,0 +1,71 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.core.dependencies import get_current_user, require_admin
+from app.core.security import decode_token
+from app.db.session import get_session
+from app.models.user import User
+from app.schemas.auth import AuthResponse, RefreshRequest, TokenPair, UserResponse
+from app.schemas.user import UserCreate
+from app.services import auth as auth_service
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/register", status_code=status.HTTP_201_CREATED, response_model=AuthResponse)
+async def register(user_in: UserCreate, session: AsyncSession = Depends(get_session)) -> AuthResponse:
+    user = await auth_service.create_user(session, user_in)
+    tokens = auth_service.issue_tokens_for_user(user)
+    return AuthResponse(user=UserResponse.model_validate(user), tokens=TokenPair(**tokens))
+
+
+@router.post("/login", response_model=AuthResponse)
+async def login(
+    user_in: UserCreate,  # reuse for email/password fields
+    session: AsyncSession = Depends(get_session),
+) -> AuthResponse:
+    user = await auth_service.authenticate_user(session, user_in.email, user_in.password)
+    tokens = auth_service.issue_tokens_for_user(user)
+    return AuthResponse(user=UserResponse.model_validate(user), tokens=TokenPair(**tokens))
+
+
+@router.post("/refresh", response_model=TokenPair)
+async def refresh_tokens(
+    refresh_request: RefreshRequest,
+    session: AsyncSession = Depends(get_session),
+) -> TokenPair:
+    payload = decode_token(refresh_request.refresh_token)
+    if not payload or payload.get("type") != "refresh":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token")
+
+    from uuid import UUID
+
+    try:
+        user_id = UUID(str(payload.get("sub")))
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+
+    result = await session.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+    tokens = auth_service.issue_tokens_for_user(user)
+    return TokenPair(**tokens)
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(current_user: User = Depends(get_current_user)) -> None:
+    # Stateless JWT logout: clients should drop tokens.
+    return None
+
+
+@router.get("/me", response_model=UserResponse)
+async def read_me(current_user: User = Depends(get_current_user)) -> UserResponse:
+    return UserResponse.model_validate(current_user)
+
+
+@router.get("/admin/ping", response_model=dict[str, str])
+async def admin_ping(admin_user: User = Depends(require_admin)) -> dict[str, str]:
+    return {"status": "admin-ok", "user": str(admin_user.id)}

--- a/backend/app/api/v1/routes.py
+++ b/backend/app/api/v1/routes.py
@@ -1,6 +1,10 @@
 from fastapi import APIRouter
 
+from app.api.v1 import auth
+
 api_router = APIRouter()
+
+api_router.include_router(auth.router)
 
 
 @api_router.get("/health", tags=["health"])

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -15,6 +15,9 @@ class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/adrianaart"
     secret_key: str = "dev-secret-key"
     stripe_secret_key: str = "sk_test_placeholder"
+    jwt_algorithm: str = "HS256"
+    access_token_exp_minutes: int = 30
+    refresh_token_exp_days: int = 7
 
     smtp_host: str = "localhost"
     smtp_port: int = 1025

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -1,0 +1,43 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.core.security import decode_token
+from app.db.session import get_session
+from app.models.user import User, UserRole
+from uuid import UUID
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    session: AsyncSession = Depends(get_session),
+) -> User:
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+
+    payload = decode_token(credentials.credentials)
+    if not payload or payload.get("type") != "access":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    try:
+        user_id = UUID(str(payload.get("sub")))
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+    if user_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+
+    result = await session.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+    return user
+
+
+async def require_admin(user: User = Depends(get_current_user)) -> User:
+    if user.role != UserRole.admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
+    return user

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import bcrypt
+from jose import JWTError, jwt
+
+from app.core.config import settings
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+def verify_password(password: str, hashed_password: str) -> bool:
+    try:
+        return bcrypt.checkpw(password.encode("utf-8"), hashed_password.encode("utf-8"))
+    except ValueError:
+        return False
+
+
+def _create_token(subject: str, token_type: str, expires_delta: timedelta) -> str:
+    expire = datetime.now(timezone.utc) + expires_delta
+    to_encode = {"sub": subject, "type": token_type, "exp": expire}
+    return jwt.encode(to_encode, settings.secret_key, algorithm=settings.jwt_algorithm)
+
+
+def create_access_token(subject: str) -> str:
+    return _create_token(subject, "access", timedelta(minutes=settings.access_token_exp_minutes))
+
+
+def create_refresh_token(subject: str) -> str:
+    return _create_token(subject, "refresh", timedelta(days=settings.refresh_token_exp_days))
+
+
+def decode_token(token: str) -> Optional[dict[str, Any]]:
+    try:
+        return jwt.decode(token, settings.secret_key, algorithms=[settings.jwt_algorithm])
+    except JWTError:
+        return None

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,1 @@
+# Pydantic schemas.

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from app.models.user import UserRole
+
+
+class TokenPair(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class TokenPayload(BaseModel):
+    sub: str
+    type: str
+    exp: int
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class UserResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    email: str
+    name: str | None = None
+    role: UserRole
+    created_at: datetime
+    updated_at: datetime
+
+
+class AuthResponse(BaseModel):
+    user: UserResponse
+    tokens: TokenPair

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+from app.models.user import UserRole
+
+
+class UserBase(BaseModel):
+    email: EmailStr
+    name: str | None = None
+
+
+class UserCreate(UserBase):
+    password: str = Field(min_length=8, max_length=128)
+
+
+class UserRead(UserBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    role: UserRole
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,1 @@
+# Service modules.

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,0 +1,42 @@
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.core import security
+from app.models.user import User
+from app.schemas.user import UserCreate
+
+
+async def get_user_by_email(session: AsyncSession, email: str) -> User | None:
+    result = await session.execute(select(User).where(User.email == email))
+    return result.scalar_one_or_none()
+
+
+async def create_user(session: AsyncSession, user_in: UserCreate) -> User:
+    existing = await get_user_by_email(session, user_in.email)
+    if existing:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered")
+
+    db_user = User(
+        email=user_in.email,
+        hashed_password=security.hash_password(user_in.password),
+        name=user_in.name,
+    )
+    session.add(db_user)
+    await session.commit()
+    await session.refresh(db_user)
+    return db_user
+
+
+async def authenticate_user(session: AsyncSession, email: str, password: str) -> User:
+    user = await get_user_by_email(session, email)
+    if not user or not security.verify_password(password, user.hashed_password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    return user
+
+
+def issue_tokens_for_user(user: User) -> dict[str, str]:
+    return {
+        "access_token": security.create_access_token(str(user.id)),
+        "refresh_token": security.create_refresh_token(str(user.id)),
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,5 +5,8 @@ sqlalchemy[asyncio]==2.0.31
 alembic==1.13.2
 asyncpg==0.29.0
 aiosqlite==0.20.0
+bcrypt==4.1.2
+python-jose[cryptography]==3.3.0
+email-validator==2.2.0
 httpx==0.27.0
 pytest==8.2.2

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,103 @@
+import asyncio
+from typing import Callable, Dict
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.main import app
+from app.db.base import Base
+from app.db.session import get_session
+from app.models.user import User, UserRole
+
+
+@pytest.fixture
+def test_app() -> Dict[str, object]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def init_models() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.get_event_loop().run_until_complete(init_models())
+
+    async def override_get_session():
+        async with SessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    client = TestClient(app)
+    yield {"client": client, "session_factory": SessionLocal}
+    client.close()
+    app.dependency_overrides.clear()
+
+
+def test_register_and_login_flow(test_app: Dict[str, object]) -> None:
+    client: TestClient = test_app["client"]  # type: ignore[assignment]
+
+    register_payload = {"email": "user@example.com", "password": "supersecret", "name": "User"}
+    res = client.post("/api/v1/auth/register", json=register_payload)
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert body["user"]["email"] == "user@example.com"
+    assert body["tokens"]["access_token"]
+    assert body["tokens"]["refresh_token"]
+
+    # Login
+    login_payload = {"email": "user@example.com", "password": "supersecret"}
+    res = client.post("/api/v1/auth/login", json=login_payload)
+    assert res.status_code == 200, res.text
+    tokens = res.json()["tokens"]
+    assert tokens["access_token"]
+    assert tokens["refresh_token"]
+
+    # Refresh
+    res = client.post("/api/v1/auth/refresh", json={"refresh_token": tokens["refresh_token"]})
+    assert res.status_code == 200, res.text
+    refreshed = res.json()
+    assert refreshed["access_token"]
+    assert refreshed["refresh_token"]
+
+
+def test_invalid_login_and_refresh(test_app: Dict[str, object]) -> None:
+    client: TestClient = test_app["client"]  # type: ignore[assignment]
+
+    res = client.post("/api/v1/auth/login", json={"email": "nobody@example.com", "password": "invalidpw"})
+    assert res.status_code == 401
+
+    res = client.post("/api/v1/auth/refresh", json={"refresh_token": "not-a-token"})
+    assert res.status_code == 401
+
+
+def test_admin_guard(test_app: Dict[str, object]) -> None:
+    client: TestClient = test_app["client"]  # type: ignore[assignment]
+    SessionLocal: Callable = test_app["session_factory"]  # type: ignore[assignment]
+
+    # Register user
+    res = client.post("/api/v1/auth/register", json={"email": "admin@example.com", "password": "adminpass"})
+    assert res.status_code == 201
+    access_token = res.json()["tokens"]["access_token"]
+
+    # Non-admin should be forbidden
+    res = client.get("/api/v1/auth/admin/ping", headers={"Authorization": f"Bearer {access_token}"})
+    assert res.status_code == 403
+
+    # Promote to admin directly in DB for test
+    async def promote() -> None:
+        async with SessionLocal() as session:
+            result = await session.execute(select(User).where(User.email == "admin@example.com"))
+            user = result.scalar_one()
+            user.role = UserRole.admin
+            await session.commit()
+
+    asyncio.get_event_loop().run_until_complete(promote())
+
+    # Acquire new tokens after role change
+    res = client.post("/api/v1/auth/login", json={"email": "admin@example.com", "password": "adminpass"})
+    admin_access = res.json()["tokens"]["access_token"]
+
+    res = client.get("/api/v1/auth/admin/ping", headers={"Authorization": f"Bearer {admin_access}"})
+    assert res.status_code == 200
+    assert res.json()["status"] == "admin-ok"


### PR DESCRIPTION
**Summary**
- Add password hashing, JWT utilities, and auth schemas/settings.
- Implement auth endpoints (register, login, refresh, logout) plus `/me` and admin-guarded ping.
- Add auth tests with in-memory DB, update docs/env examples, and mark backlog items complete.

**Changes**
- Added security helpers for bcrypt hashing and JWT creation/validation with settings/env defaults.
- Added FastAPI auth routes, dependencies, schemas, and service helpers; admin guard wired via dependency.
- Added auth test suite, updated README and `.env.example`, and refreshed TODO to reflect completed auth tasks.

**Testing**
- `cd backend && . .venv/bin/activate && python -m pytest`

**Risk & Impact**
- Low: adds auth scaffolding and JWT guard; no existing endpoints changed beyond router inclusion.

**Related TODO items**
- [x] Password hashing/verification.
- [x] Auth endpoints: register, login (access+refresh), refresh, logout.
- [x] JWT guard dependency + role guard for admin.
- [x] Tests for auth flows (register/login/refresh/invalid creds).