### PR TITLE
feat: add catalog models and migration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,9 +25,9 @@ Below is a structured checklist you can turn into issues.
 - [x] Tests for auth flows (register/login/refresh/invalid creds).
 
 ## Backend - Catalog & Products
-- [ ] Category model + migration.
-- [ ] Product model + migration.
-- [ ] ProductImage model + migration.
+- [x] Category model + migration.
+- [x] Product model + migration.
+- [x] ProductImage model + migration.
 - [ ] (Optional) ProductVariant model + migration.
 - [ ] GET /categories (public).
 - [ ] GET /products with pagination, search, category, price filters.

--- a/backend/alembic/versions/0002_add_catalog_models.py
+++ b/backend/alembic/versions/0002_add_catalog_models.py
@@ -1,0 +1,81 @@
+"""add catalog models
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2024-10-05
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "categories",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("slug", sa.String(length=120), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("slug", name="uq_categories_slug"),
+    )
+    op.create_index("ix_categories_slug", "categories", ["slug"], unique=True)
+
+    op.create_table(
+        "products",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("category_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("categories.id"), nullable=False),
+        sa.Column("slug", sa.String(length=160), nullable=False),
+        sa.Column("name", sa.String(length=160), nullable=False),
+        sa.Column("short_description", sa.String(length=280), nullable=True),
+        sa.Column("long_description", sa.Text(), nullable=True),
+        sa.Column("base_price", sa.Numeric(10, 2), nullable=False, server_default="0"),
+        sa.Column("currency", sa.String(length=3), nullable=False, server_default="USD"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("is_featured", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("stock_quantity", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("slug", name="uq_products_slug"),
+    )
+    op.create_index("ix_products_slug", "products", ["slug"], unique=True)
+
+    op.create_table(
+        "product_images",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("product_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("products.id"), nullable=False),
+        sa.Column("url", sa.String(length=500), nullable=False),
+        sa.Column("alt_text", sa.String(length=255), nullable=True),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("product_images")
+    op.drop_index("ix_products_slug", table_name="products")
+    op.drop_table("products")
+    op.drop_index("ix_categories_slug", table_name="categories")
+    op.drop_table("categories")

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -9,7 +9,6 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 class Base(DeclarativeBase):
     """Base class for all ORM models."""
 
-
 class TimestampMixin:
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
 from app.db.base import Base  # noqa: F401
 from app.models.user import User  # noqa: F401
+from app.models.catalog import Category, Product, ProductImage  # noqa: F401
 
-__all__ = ["Base", "User"]
+__all__ = ["Base", "User", "Category", "Product", "ProductImage"]

--- a/backend/app/models/catalog.py
+++ b/backend/app/models/catalog.py
@@ -1,0 +1,73 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Numeric, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class Category(Base):
+    __tablename__ = "categories"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    slug: Mapped[str] = mapped_column(String(120), unique=True, nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    products: Mapped[list["Product"]] = relationship("Product", back_populates="category")
+
+
+class Product(Base):
+    __tablename__ = "products"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    category_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("categories.id"), nullable=False)
+    slug: Mapped[str] = mapped_column(String(160), unique=True, nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(160), nullable=False)
+    short_description: Mapped[str | None] = mapped_column(String(280), nullable=True)
+    long_description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    base_price: Mapped[float] = mapped_column(Numeric(10, 2), nullable=False, default=0)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False, default="USD")
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    is_featured: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    stock_quantity: Mapped[int] = mapped_column(nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    category: Mapped[Category] = relationship("Category", back_populates="products")
+    images: Mapped[list["ProductImage"]] = relationship(
+        "ProductImage", back_populates="product", cascade="all, delete-orphan"
+    )
+
+
+class ProductImage(Base):
+    __tablename__ = "product_images"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    product_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("products.id"), nullable=False)
+    url: Mapped[str] = mapped_column(String(500), nullable=False)
+    alt_text: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    sort_order: Mapped[int] = mapped_column(nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    product: Mapped[Product] = relationship("Product", back_populates="images")

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.db.base import Base
 from app.models.user import User, UserRole
+from app.models.catalog import Category, Product, ProductImage
 
 
 @pytest.fixture
@@ -29,3 +30,31 @@ async def test_user_model_persists_in_sqlite_memory() -> None:
         fetched = result.scalar_one()
         assert fetched.id is not None
         assert fetched.role == UserRole.customer
+
+
+@pytest.mark.anyio("asyncio")
+async def test_catalog_models_sqlite_memory() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with SessionLocal() as session:
+        category = Category(slug="cups", name="Cups")
+        product = Product(
+            category=category,
+            slug="white-cup",
+            name="White Cup",
+            base_price=15.50,
+            currency="USD",
+            stock_quantity=5,
+        )
+        image = ProductImage(product=product, url="http://example.com/cup.jpg", alt_text="Cup", sort_order=1)
+        session.add_all([category, product, image])
+        await session.commit()
+
+        result = await session.execute(select(Product).where(Product.slug == "white-cup"))
+        fetched = result.scalar_one()
+        assert fetched.category.slug == "cups"
+        assert fetched.images[0].url.endswith("cup.jpg")


### PR DESCRIPTION
**Summary**
- Add catalog data models for categories, products, and product images with relationships.
- Introduce Alembic migration for the new tables.
- Cover models with a basic SQLite persistence test and update backlog.

**Changes**
- Added `Category`, `Product`, and `ProductImage` ORM models and wired them into the models package.
- Added Alembic migration `0002` to create catalog tables with indexes and constraints.
- Expanded DB test suite to validate catalog relationships; updated TODO to mark catalog model tasks done.

**Testing**
- `cd backend && . .venv/bin/activate && python -m pytest`

**Risk & Impact**
- Low: schema additions only; no API behavior changes yet.

**Related TODO items**
- [x] Category model + migration.
- [x] Product model + migration.
- [x] ProductImage model + migration.