### PR TITLE
feat: add catalog api endpoints and tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,7 +32,7 @@ Below is a structured checklist you can turn into issues.
 - [ ] GET /categories (public).
 - [ ] GET /products with pagination, search, category, price filters.
 - [ ] GET /products/{slug} detail.
-- [ ] Admin create/update product endpoints.
+- [x] Admin create/update product endpoints.
 - [ ] Admin soft-delete product.
 - [ ] Admin product image upload/delete.
 - [ ] Image storage service (local first, S3-ready).

--- a/backend/app/api/v1/catalog.py
+++ b/backend/app/api/v1/catalog.py
@@ -1,0 +1,97 @@
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy.orm import selectinload
+
+from app.core.dependencies import get_current_user, require_admin
+from app.db.session import get_session
+from app.models.catalog import Category, Product
+from app.schemas.catalog import (
+    CategoryCreate,
+    CategoryRead,
+    CategoryUpdate,
+    ProductCreate,
+    ProductRead,
+    ProductUpdate,
+)
+from app.services import catalog as catalog_service
+
+router = APIRouter(prefix="/catalog", tags=["catalog"])
+
+
+@router.get("/categories", response_model=list[CategoryRead])
+async def list_categories(session: AsyncSession = Depends(get_session)) -> list[Category]:
+    result = await session.execute(select(Category).order_by(Category.name))
+    return list(result.scalars())
+
+
+@router.get("/products", response_model=list[ProductRead])
+async def list_products(
+    session: AsyncSession = Depends(get_session),
+    category_slug: str | None = Query(default=None),
+    is_featured: bool | None = Query(default=None),
+) -> list[Product]:
+    query = select(Product).options(selectinload(Product.images), selectinload(Product.category))
+    if category_slug:
+        query = query.join(Category).where(Category.slug == category_slug)
+    if is_featured is not None:
+        query = query.where(Product.is_featured == is_featured)
+    result = await session.execute(query.order_by(Product.created_at.desc()))
+    return list(result.scalars().unique())
+
+
+@router.get("/products/{slug}", response_model=ProductRead)
+async def get_product(slug: str, session: AsyncSession = Depends(get_session)) -> Product:
+    product = await catalog_service.get_product_by_slug(
+        session, slug, options=[selectinload(Product.images), selectinload(Product.category)]
+    )
+    if not product:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return product
+
+
+# Admin endpoints
+
+
+@router.post("/categories", response_model=CategoryRead, status_code=status.HTTP_201_CREATED)
+async def create_category(
+    payload: CategoryCreate,
+    session: AsyncSession = Depends(get_session),
+    _: str = Depends(require_admin),
+) -> Category:
+    return await catalog_service.create_category(session, payload)
+
+
+@router.patch("/categories/{slug}", response_model=CategoryRead)
+async def update_category(
+    slug: str,
+    payload: CategoryUpdate,
+    session: AsyncSession = Depends(get_session),
+    _: str = Depends(require_admin),
+) -> Category:
+    category = await catalog_service.get_category_by_slug(session, slug)
+    if not category:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+    return await catalog_service.update_category(session, category, payload)
+
+
+@router.post("/products", response_model=ProductRead, status_code=status.HTTP_201_CREATED)
+async def create_product(
+    payload: ProductCreate,
+    session: AsyncSession = Depends(get_session),
+    _: str = Depends(require_admin),
+) -> Product:
+    return await catalog_service.create_product(session, payload)
+
+
+@router.patch("/products/{slug}", response_model=ProductRead)
+async def update_product(
+    slug: str,
+    payload: ProductUpdate,
+    session: AsyncSession = Depends(get_session),
+    _: str = Depends(require_admin),
+) -> Product:
+    product = await catalog_service.get_product_by_slug(session, slug)
+    if not product:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return await catalog_service.update_product(session, product, payload)

--- a/backend/app/api/v1/routes.py
+++ b/backend/app/api/v1/routes.py
@@ -1,10 +1,12 @@
 from fastapi import APIRouter
 
 from app.api.v1 import auth
+from app.api.v1 import catalog
 
 api_router = APIRouter()
 
 api_router.include_router(auth.router)
+api_router.include_router(catalog.router)
 
 
 @api_router.get("/health", tags=["health"])

--- a/backend/app/models/catalog.py
+++ b/backend/app/models/catalog.py
@@ -52,9 +52,12 @@ class Product(Base):
         nullable=False,
     )
 
-    category: Mapped[Category] = relationship("Category", back_populates="products")
+    category: Mapped[Category] = relationship("Category", back_populates="products", lazy="joined")
     images: Mapped[list["ProductImage"]] = relationship(
-        "ProductImage", back_populates="product", cascade="all, delete-orphan"
+        "ProductImage",
+        back_populates="product",
+        cascade="all, delete-orphan",
+        lazy="selectin",
     )
 
 

--- a/backend/app/schemas/catalog.py
+++ b/backend/app/schemas/catalog.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CategoryBase(BaseModel):
+    slug: str = Field(min_length=1, max_length=120)
+    name: str = Field(min_length=1, max_length=120)
+    description: str | None = None
+
+
+class CategoryCreate(CategoryBase):
+    pass
+
+
+class CategoryUpdate(BaseModel):
+    name: str | None = Field(default=None, max_length=120)
+    description: str | None = None
+
+
+class CategoryRead(CategoryBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProductBase(BaseModel):
+    category_id: UUID
+    slug: str = Field(min_length=1, max_length=160)
+    name: str = Field(min_length=1, max_length=160)
+    short_description: str | None = Field(default=None, max_length=280)
+    long_description: str | None = None
+    base_price: float = Field(ge=0)
+    currency: str = Field(min_length=3, max_length=3)
+    is_active: bool = True
+    is_featured: bool = False
+    stock_quantity: int = Field(ge=0)
+
+
+class ProductCreate(ProductBase):
+    images: list["ProductImageCreate"] = []
+
+
+class ProductUpdate(BaseModel):
+    name: str | None = Field(default=None, max_length=160)
+    short_description: str | None = Field(default=None, max_length=280)
+    long_description: str | None = None
+    base_price: float | None = Field(default=None, ge=0)
+    currency: str | None = Field(default=None, min_length=3, max_length=3)
+    is_active: bool | None = None
+    is_featured: bool | None = None
+    stock_quantity: int | None = Field(default=None, ge=0)
+    category_id: UUID | None = None
+
+
+class ProductImageBase(BaseModel):
+    url: str
+    alt_text: str | None = None
+    sort_order: int = 0
+
+
+class ProductImageCreate(ProductImageBase):
+    pass
+
+
+class ProductImageRead(ProductImageBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+
+
+class ProductRead(ProductBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+    images: list[ProductImageRead] = []
+    category: CategoryRead

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,1 +1,4 @@
 # Service modules.
+from app.services import auth, catalog
+
+__all__ = ["auth", "catalog"]

--- a/backend/app/services/catalog.py
+++ b/backend/app/services/catalog.py
@@ -1,0 +1,81 @@
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy.orm import selectinload
+
+from app.models.catalog import Category, Product, ProductImage
+from app.schemas.catalog import (
+    CategoryCreate,
+    CategoryUpdate,
+    ProductCreate,
+    ProductImageCreate,
+    ProductUpdate,
+)
+
+
+async def get_category_by_slug(session: AsyncSession, slug: str) -> Category | None:
+    result = await session.execute(select(Category).where(Category.slug == slug))
+    return result.scalar_one_or_none()
+
+
+async def get_product_by_slug(
+    session: AsyncSession, slug: str, options: list | None = None
+) -> Product | None:
+    query = select(Product)
+    if options:
+        for opt in options:
+            query = query.options(opt)
+    result = await session.execute(query.where(Product.slug == slug))
+    return result.scalar_one_or_none()
+
+
+async def create_category(session: AsyncSession, payload: CategoryCreate) -> Category:
+    existing = await get_category_by_slug(session, payload.slug)
+    if existing:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Category slug already exists")
+    category = Category(**payload.model_dump())
+    session.add(category)
+    await session.commit()
+    await session.refresh(category)
+    return category
+
+
+async def update_category(session: AsyncSession, category: Category, payload: CategoryUpdate) -> Category:
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(category, field, value)
+    session.add(category)
+    await session.commit()
+    await session.refresh(category)
+    return category
+
+
+async def create_product(session: AsyncSession, payload: ProductCreate) -> Product:
+    existing = await get_product_by_slug(session, payload.slug)
+    if existing:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Product slug already exists")
+
+    images_payload = payload.images or []
+    product_data = payload.model_dump(exclude={"images"})
+    product = Product(**product_data)
+    product.images = [ProductImage(**img.model_dump()) for img in images_payload]
+    session.add(product)
+    await session.commit()
+    await session.refresh(product)
+    return product
+
+
+async def update_product(session: AsyncSession, product: Product, payload: ProductUpdate) -> Product:
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(product, field, value)
+    session.add(product)
+    await session.commit()
+    await session.refresh(product)
+    return product
+
+
+async def add_product_image(session: AsyncSession, product: Product, payload: ProductImageCreate) -> ProductImage:
+    image = ProductImage(product=product, **payload.model_dump())
+    session.add(image)
+    await session.commit()
+    await session.refresh(image)
+    return image

--- a/backend/tests/test_catalog_api.py
+++ b/backend/tests/test_catalog_api.py
@@ -1,0 +1,104 @@
+import asyncio
+from typing import Dict
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.main import app
+from app.db.base import Base
+from app.db.session import get_session
+from app.models.user import UserRole
+from app.services.auth import create_user
+from app.schemas.user import UserCreate
+
+
+@pytest.fixture
+def test_app() -> Dict[str, object]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def init_models() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.get_event_loop().run_until_complete(init_models())
+
+    async def override_get_session():
+        async with SessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    client = TestClient(app)
+    yield {"client": client, "session_factory": SessionLocal}
+    client.close()
+    app.dependency_overrides.clear()
+
+
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def create_admin_token(session_factory, email="admin@example.com"):
+    async def create_admin():
+        async with session_factory() as session:
+            user = await create_user(session, UserCreate(email=email, password="adminpass", name="Admin"))
+            user.role = UserRole.admin
+            await session.commit()
+            from app.services.auth import issue_tokens_for_user
+
+            return issue_tokens_for_user(user)["access_token"]
+
+    return asyncio.get_event_loop().run_until_complete(create_admin())
+
+
+def test_catalog_admin_and_public_flows(test_app: Dict[str, object]) -> None:
+    client: TestClient = test_app["client"]  # type: ignore[assignment]
+    SessionLocal = test_app["session_factory"]  # type: ignore[assignment]
+
+    admin_token = create_admin_token(SessionLocal)
+
+    # Create category
+    res = client.post(
+        "/api/v1/catalog/categories",
+        json={"slug": "cups", "name": "Cups"},
+        headers=auth_headers(admin_token),
+    )
+    assert res.status_code == 201, res.text
+
+    # Create product
+    res = client.post(
+        "/api/v1/catalog/products",
+        json={
+            "category_id": res.json()["id"],
+            "slug": "white-cup",
+            "name": "White Cup",
+            "base_price": 10.5,
+            "currency": "USD",
+            "stock_quantity": 3,
+            "images": [{"url": "http://example.com/cup.jpg", "alt_text": "Cup", "sort_order": 1}],
+        },
+        headers=auth_headers(admin_token),
+    )
+    assert res.status_code == 201, res.text
+
+    # Public list
+    res = client.get("/api/v1/catalog/products")
+    assert res.status_code == 200
+    assert len(res.json()) == 1
+    assert res.json()[0]["slug"] == "white-cup"
+
+    # Public detail
+    res = client.get("/api/v1/catalog/products/white-cup")
+    assert res.status_code == 200
+    assert res.json()["slug"] == "white-cup"
+    assert res.json()["images"][0]["url"].endswith("cup.jpg")
+
+    # Update product
+    res = client.patch(
+        "/api/v1/catalog/products/white-cup",
+        json={"stock_quantity": 10},
+        headers=auth_headers(admin_token),
+    )
+    assert res.status_code == 200
+    assert res.json()["stock_quantity"] == 10


### PR DESCRIPTION
**Summary**
- Add catalog schemas, services, and API endpoints for categories and products with public list/detail and admin create/update.
- Wire relationships with eager loading to avoid async lazy-load issues and include catalog router in v1 API.
- Cover catalog flows with tests using in-memory SQLite; update backlog accordingly.

**Changes**
- Added `catalog` router under `/api/v1/catalog` with endpoints: list categories, list products (with filters), product detail, admin create/update category, admin create/update product.
- Added catalog schemas and service helpers; set Product relationships to use selectin/joined loading for images/category.
- Added catalog API test suite; updated TODO items for admin product endpoints.

**Testing**
- `cd backend && . .venv/bin/activate && python -m pytest`

**Risk & Impact**
- Low: adds API surface and eager loading; no breaking changes to existing endpoints.

**Related TODO items**
- [x] Admin create/update product endpoints.
- (Public product/category list/detail implemented ahead of checklist items).