### PR TITLE
feat: add catalog seeds and cart models

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,10 +36,10 @@ Below is a structured checklist you can turn into issues.
 - [x] Admin soft-delete product.
 - [x] Admin product image upload/delete.
 - [x] Image storage service (local first, S3-ready).
-- [ ] Seed example products/categories for dev.
+- [x] Seed example products/categories for dev.
 
 ## Backend - Cart & Checkout
-- [ ] Cart + CartItem models + migrations.
+- [x] Cart + CartItem models + migrations.
 - [ ] Guest cart support (session_id).
 - [ ] GET /cart (guest or user).
 - [ ] POST /cart/items add.

--- a/backend/alembic/versions/0005_add_cart_models.py
+++ b/backend/alembic/versions/0005_add_cart_models.py
@@ -1,0 +1,54 @@
+"""add cart models
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2024-10-05
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "carts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=True),
+        sa.Column("session_id", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("session_id", name="uq_carts_session_id"),
+    )
+    op.create_index("ix_carts_session_id", "carts", ["session_id"], unique=True)
+
+    op.create_table(
+        "cart_items",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("cart_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("carts.id"), nullable=False),
+        sa.Column("product_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("products.id"), nullable=False),
+        sa.Column("variant_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("product_variants.id"), nullable=True),
+        sa.Column("quantity", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("unit_price_at_add", sa.Numeric(10, 2), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("cart_items")
+    op.drop_index("ix_carts_session_id", table_name="carts")
+    op.drop_table("carts")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.db.base import Base  # noqa: F401
 from app.models.user import User  # noqa: F401
 from app.models.catalog import Category, Product, ProductImage, ProductVariant  # noqa: F401
+from app.models.cart import Cart, CartItem  # noqa: F401
 
-__all__ = ["Base", "User", "Category", "Product", "ProductImage", "ProductVariant"]
+__all__ = ["Base", "User", "Category", "Product", "ProductImage", "ProductVariant", "Cart", "CartItem"]

--- a/backend/app/models/cart.py
+++ b/backend/app/models/cart.py
@@ -1,0 +1,47 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Numeric, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.models.catalog import Product, ProductVariant
+from app.models.user import User
+
+
+class Cart(Base):
+    __tablename__ = "carts"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    session_id: Mapped[str | None] = mapped_column(String(255), nullable=True, unique=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    user: Mapped[User | None] = relationship("User")
+    items: Mapped[list["CartItem"]] = relationship(
+        "CartItem", back_populates="cart", cascade="all, delete-orphan"
+    )
+
+
+class CartItem(Base):
+    __tablename__ = "cart_items"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    cart_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("carts.id"), nullable=False)
+    product_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("products.id"), nullable=False)
+    variant_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("product_variants.id"), nullable=True)
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    unit_price_at_add: Mapped[float] = mapped_column(Numeric(10, 2), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    cart: Mapped[Cart] = relationship("Cart", back_populates="items")
+    product: Mapped[Product] = relationship("Product")
+    variant: Mapped[ProductVariant | None] = relationship("ProductVariant")

--- a/backend/app/seeds.py
+++ b/backend/app/seeds.py
@@ -1,0 +1,102 @@
+import asyncio
+import uuid
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.future import select
+
+from app.core.config import settings
+from app.models.catalog import Category, Product, ProductImage, ProductVariant
+
+
+SEED_CATEGORIES = [
+    {"slug": "cups", "name": "Cups & Mugs", "description": "Handmade cups and mugs."},
+    {"slug": "plates", "name": "Plates", "description": "Dinner and side plates."},
+    {"slug": "bowls", "name": "Bowls", "description": "Serving and cereal bowls."},
+]
+
+SEED_PRODUCTS = [
+    {
+        "slug": "white-cup",
+        "name": "White Glazed Cup",
+        "category_slug": "cups",
+        "short_description": "Matte white glaze, comfortable handle.",
+        "long_description": "Wheel-thrown stoneware with white matte glaze and speckle.",
+        "base_price": Decimal("24.00"),
+        "currency": "USD",
+        "stock_quantity": 10,
+        "is_featured": True,
+        "images": [
+            {"url": "https://example.com/images/white-cup-1.jpg", "alt_text": "White cup front", "sort_order": 1},
+            {"url": "https://example.com/images/white-cup-2.jpg", "alt_text": "White cup angle", "sort_order": 2},
+        ],
+        "variants": [
+            {"name": "8oz", "additional_price_delta": Decimal("0.00"), "stock_quantity": 5},
+            {"name": "12oz", "additional_price_delta": Decimal("4.00"), "stock_quantity": 5},
+        ],
+    },
+    {
+        "slug": "blue-bowl",
+        "name": "Blue Splash Bowl",
+        "category_slug": "bowls",
+        "short_description": "Splash glaze interior with raw exterior.",
+        "long_description": "Medium bowl perfect for ramen or salads.",
+        "base_price": Decimal("36.00"),
+        "currency": "USD",
+        "stock_quantity": 6,
+        "is_featured": False,
+        "images": [
+            {"url": "https://example.com/images/blue-bowl-1.jpg", "alt_text": "Blue bowl top", "sort_order": 1},
+        ],
+        "variants": [],
+    },
+]
+
+
+async def seed(session: AsyncSession) -> None:
+    # Categories
+    for cat in SEED_CATEGORIES:
+        existing = await session.execute(select(Category).where(Category.slug == cat["slug"]))
+        if existing.scalar_one_or_none():
+            continue
+        session.add(Category(**cat))
+    await session.commit()
+
+    # Products
+    for prod in SEED_PRODUCTS:
+        result = await session.execute(select(Product).where(Product.slug == prod["slug"]))
+        if result.scalar_one_or_none():
+            continue
+
+        cat_result = await session.execute(select(Category).where(Category.slug == prod["category_slug"]))
+        category = cat_result.scalar_one()
+
+        product = Product(
+            category_id=category.id,
+            slug=prod["slug"],
+            name=prod["name"],
+            short_description=prod["short_description"],
+            long_description=prod["long_description"],
+            base_price=prod["base_price"],
+            currency=prod["currency"],
+            is_active=True,
+            is_featured=prod["is_featured"],
+            stock_quantity=prod["stock_quantity"],
+        )
+        product.images = [ProductImage(**img) for img in prod["images"]]
+        product.variants = [ProductVariant(**variant) for variant in prod["variants"]]
+        session.add(product)
+
+    await session.commit()
+
+
+async def main() -> None:
+    engine = create_async_engine(settings.database_url, future=True, echo=False)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    async with SessionLocal() as session:
+        await seed(session)
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -4,7 +4,8 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.db.base import Base
 from app.models.user import User, UserRole
-from app.models.catalog import Category, Product, ProductImage
+from app.models.catalog import Category, Product, ProductImage, ProductVariant
+from app.models.cart import Cart, CartItem
 
 
 @pytest.fixture
@@ -50,6 +51,7 @@ async def test_catalog_models_sqlite_memory() -> None:
             currency="USD",
             stock_quantity=5,
         )
+        product.variants = [ProductVariant(name="Large", additional_price_delta=2.0, stock_quantity=1)]
         image = ProductImage(product=product, url="http://example.com/cup.jpg", alt_text="Cup", sort_order=1)
         session.add_all([category, product, image])
         await session.commit()
@@ -58,3 +60,35 @@ async def test_catalog_models_sqlite_memory() -> None:
         fetched = result.scalar_one()
         assert fetched.category.slug == "cups"
         assert fetched.images[0].url.endswith("cup.jpg")
+        assert fetched.variants[0].name == "Large"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_cart_models_sqlite_memory() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    async with SessionLocal() as session:
+        category = Category(slug="plates", name="Plates")
+        product = Product(
+            category=category,
+            slug="plate",
+            name="Plate",
+            base_price=20,
+            currency="USD",
+            stock_quantity=2,
+        )
+        session.add_all([category, product])
+        await session.commit()
+
+        cart = Cart(session_id="guest-123")
+        item = CartItem(cart=cart, product=product, quantity=2, unit_price_at_add=product.base_price)
+        session.add(cart)
+        await session.commit()
+
+        result = await session.execute(select(CartItem).where(CartItem.cart == cart))
+        fetched = result.scalar_one()
+        assert fetched.quantity == 2
+        assert float(fetched.unit_price_at_add) == 20.0


### PR DESCRIPTION
**Summary**
- Add seed script for categories/products/images/variants to populate dev data quickly.
- Add Cart and CartItem models with migration to prepare for cart/checkout flows.
- Add basic tests for catalog variants and cart models; update backlog status.

**Changes**
- Added `backend/app/seeds.py` with sample categories/products/images/variants using the configured DB.
- Added cart and cart item ORM models and Alembic migration `0005`.
- Updated shared models import, expanded DB tests for variants and cart, and marked TODO items for seeding and cart models.

**Testing**
- `cd backend && . .venv/bin/activate && python -m pytest -q`

**Risk & Impact**
- Low: additive models and seed script; no API behavior changes yet.

**Related TODO items**
- [x] Seed example products/categories for dev.
- [x] Cart + CartItem models + migrations.