### PR TITLE
feat: add address model and /me/addresses endpoints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -49,7 +49,7 @@ Below is a structured checklist you can turn into issues.
 - [ ] Merge guest cart into user cart on login.
 
 ## Backend - Orders, Payment, Addresses
-- [ ] Address model + migration; CRUD /me/addresses.
+- [x] Address model + migration; CRUD /me/addresses.
 - [ ] Order + OrderItem models + migrations.
 - [ ] Service to build order from cart (price snapshot).
 - [ ] Stripe integration: PaymentIntent create, return client secret.

--- a/backend/alembic/versions/0006_add_addresses.py
+++ b/backend/alembic/versions/0006_add_addresses.py
@@ -1,0 +1,49 @@
+"""add addresses
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2024-10-05
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "addresses",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("label", sa.String(length=50), nullable=True),
+        sa.Column("line1", sa.String(length=200), nullable=False),
+        sa.Column("line2", sa.String(length=200), nullable=True),
+        sa.Column("city", sa.String(length=100), nullable=False),
+        sa.Column("region", sa.String(length=100), nullable=True),
+        sa.Column("postal_code", sa.String(length=20), nullable=False),
+        sa.Column("country", sa.String(length=2), nullable=False),
+        sa.Column("is_default_shipping", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("is_default_billing", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_addresses_user_id", "addresses", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_addresses_user_id", table_name="addresses")
+    op.drop_table("addresses")

--- a/backend/app/api/v1/addresses.py
+++ b/backend/app/api/v1/addresses.py
@@ -1,0 +1,51 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import get_current_user
+from app.db.session import get_session
+from app.schemas.address import AddressCreate, AddressRead, AddressUpdate
+from app.services import address as address_service
+
+router = APIRouter(prefix="/me/addresses", tags=["addresses"])
+
+
+@router.get("", response_model=list[AddressRead])
+async def list_addresses(current_user=Depends(get_current_user), session: AsyncSession = Depends(get_session)):
+    return await address_service.list_addresses(session, current_user.id)
+
+
+@router.post("", response_model=AddressRead, status_code=status.HTTP_201_CREATED)
+async def create_address(
+    payload: AddressCreate,
+    current_user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    return await address_service.create_address(session, current_user.id, payload)
+
+
+@router.patch("/{address_id}", response_model=AddressRead)
+async def update_address(
+    address_id: UUID,
+    payload: AddressUpdate,
+    current_user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    address = await address_service.get_address(session, current_user.id, address_id)
+    if not address:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Address not found")
+    return await address_service.update_address(session, address, payload)
+
+
+@router.delete("/{address_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_address(
+    address_id: UUID,
+    current_user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    address = await address_service.get_address(session, current_user.id, address_id)
+    if not address:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Address not found")
+    await address_service.delete_address(session, address)
+    return None

--- a/backend/app/api/v1/routes.py
+++ b/backend/app/api/v1/routes.py
@@ -3,12 +3,14 @@ from fastapi import APIRouter
 from app.api.v1 import auth
 from app.api.v1 import catalog
 from app.api.v1 import cart
+from app.api.v1 import addresses
 
 api_router = APIRouter()
 
 api_router.include_router(auth.router)
 api_router.include_router(catalog.router)
 api_router.include_router(cart.router)
+api_router.include_router(addresses.router)
 
 
 @api_router.get("/health", tags=["health"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,5 +2,16 @@ from app.db.base import Base  # noqa: F401
 from app.models.user import User  # noqa: F401
 from app.models.catalog import Category, Product, ProductImage, ProductVariant  # noqa: F401
 from app.models.cart import Cart, CartItem  # noqa: F401
+from app.models.address import Address  # noqa: F401
 
-__all__ = ["Base", "User", "Category", "Product", "ProductImage", "ProductVariant", "Cart", "CartItem"]
+__all__ = [
+    "Base",
+    "User",
+    "Category",
+    "Product",
+    "ProductImage",
+    "ProductVariant",
+    "Cart",
+    "CartItem",
+    "Address",
+]

--- a/backend/app/models/address.py
+++ b/backend/app/models/address.py
@@ -1,0 +1,33 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.models.user import User
+
+
+class Address(Base):
+    __tablename__ = "addresses"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    label: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    line1: Mapped[str] = mapped_column(String(200), nullable=False)
+    line2: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    city: Mapped[str] = mapped_column(String(100), nullable=False)
+    region: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    postal_code: Mapped[str] = mapped_column(String(20), nullable=False)
+    country: Mapped[str] = mapped_column(String(2), nullable=False)
+    is_default_shipping: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    is_default_billing: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    user: Mapped[User] = relationship("User")

--- a/backend/app/schemas/address.py
+++ b/backend/app/schemas/address.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AddressBase(BaseModel):
+    label: str | None = Field(default=None, max_length=50)
+    line1: str = Field(min_length=1, max_length=200)
+    line2: str | None = Field(default=None, max_length=200)
+    city: str = Field(min_length=1, max_length=100)
+    region: str | None = Field(default=None, max_length=100)
+    postal_code: str = Field(min_length=1, max_length=20)
+    country: str = Field(min_length=2, max_length=2)
+    is_default_shipping: bool = False
+    is_default_billing: bool = False
+
+
+class AddressCreate(AddressBase):
+    pass
+
+
+class AddressUpdate(BaseModel):
+    label: str | None = Field(default=None, max_length=50)
+    line1: str | None = Field(default=None, max_length=200)
+    line2: str | None = Field(default=None, max_length=200)
+    city: str | None = Field(default=None, max_length=100)
+    region: str | None = Field(default=None, max_length=100)
+    postal_code: str | None = Field(default=None, max_length=20)
+    country: str | None = Field(default=None, max_length=2)
+    is_default_shipping: bool | None = None
+    is_default_billing: bool | None = None
+
+
+class AddressRead(AddressBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    user_id: UUID
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/address.py
+++ b/backend/app/services/address.py
@@ -1,0 +1,64 @@
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.models.address import Address
+from app.schemas.address import AddressCreate, AddressUpdate
+
+
+async def list_addresses(session: AsyncSession, user_id) -> list[Address]:
+    result = await session.execute(select(Address).where(Address.user_id == user_id))
+    return list(result.scalars())
+
+
+async def create_address(session: AsyncSession, user_id, payload: AddressCreate) -> Address:
+    address = Address(user_id=user_id, **payload.model_dump())
+    session.add(address)
+    if payload.is_default_shipping or payload.is_default_billing:
+        await _clear_defaults(session, user_id, payload.is_default_shipping, payload.is_default_billing)
+    await session.commit()
+    await session.refresh(address)
+    return address
+
+
+async def update_address(session: AsyncSession, address: Address, payload: AddressUpdate) -> Address:
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(address, field, value)
+    if payload.is_default_shipping or payload.is_default_billing:
+        await _clear_defaults(
+            session,
+            address.user_id,
+            payload.is_default_shipping if payload.is_default_shipping is not None else False,
+            payload.is_default_billing if payload.is_default_billing is not None else False,
+            exclude_id=address.id,
+        )
+    session.add(address)
+    await session.commit()
+    await session.refresh(address)
+    return address
+
+
+async def delete_address(session: AsyncSession, address: Address) -> None:
+    await session.delete(address)
+    await session.commit()
+
+
+async def get_address(session: AsyncSession, user_id, address_id) -> Address | None:
+    result = await session.execute(select(Address).where(Address.user_id == user_id, Address.id == address_id))
+    return result.scalar_one_or_none()
+
+
+async def _clear_defaults(session: AsyncSession, user_id, shipping: bool, billing: bool, exclude_id=None) -> None:
+    if not shipping and not billing:
+        return
+    result = await session.execute(select(Address).where(Address.user_id == user_id))
+    addresses = result.scalars().all()
+    for addr in addresses:
+        if exclude_id and addr.id == exclude_id:
+            continue
+        if shipping:
+            addr.is_default_shipping = False
+        if billing:
+            addr.is_default_billing = False
+        session.add(addr)
+    await session.flush()


### PR DESCRIPTION
**Summary**
- Add Address model and migration with user defaults for shipping/billing.
- Expose /me/addresses CRUD endpoints with default-handling validation.
- Update TODO backlog for address work.

**Changes**
- Added Address ORM model, Alembic migration 0006, schemas, and service helpers.
- Added `/api/v1/me/addresses` endpoints for list/create/update/delete; routes wired into API.
- Updated models exports and TODO to mark address task done.

**Testing**
- `cd backend && . .venv/bin/activate && python -m pytest -q`

**Risk & Impact**
- Low: additive schema and endpoints; no breaking changes to existing APIs.

**Related TODO items**
- [x] Address model + migration; CRUD /me/addresses.