### PR TITLE
feat: add order builder and user order endpoints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,10 +51,10 @@ Below is a structured checklist you can turn into issues.
 ## Backend - Orders, Payment, Addresses
 - [x] Address model + migration; CRUD /me/addresses.
 - [x] Order + OrderItem models + migrations.
-- [ ] Service to build order from cart (price snapshot).
+- [x] Service to build order from cart (price snapshot).
 - [ ] Stripe integration: PaymentIntent create, return client secret.
 - [ ] Stripe webhook for payment succeeded/failed; update status.
-- [ ] GET /me/orders and /me/orders/{id}.
+- [x] GET /me/orders and /me/orders/{id}.
 - [ ] Admin order list/filter + status/tracking update.
 
 ## Backend - CMS & Content

--- a/backend/app/api/v1/orders.py
+++ b/backend/app/api/v1/orders.py
@@ -1,0 +1,59 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy.orm import selectinload
+
+from app.core.dependencies import get_current_user
+from app.db.session import get_session
+from app.models.address import Address
+from app.models.cart import Cart
+from app.schemas.order import OrderRead
+from app.services import order as order_service
+
+router = APIRouter(prefix="/orders", tags=["orders"])
+
+
+@router.post("", response_model=OrderRead, status_code=status.HTTP_201_CREATED)
+async def create_order(
+    shipping_address_id: UUID | None,
+    billing_address_id: UUID | None,
+    session: AsyncSession = Depends(get_session),
+    current_user=Depends(get_current_user),
+):
+    cart_result = await session.execute(
+        select(Cart).options(selectinload(Cart.items)).where(Cart.user_id == current_user.id)
+    )
+    cart = cart_result.scalar_one_or_none()
+    if not cart or not cart.items:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cart is empty")
+
+    for address_id in [shipping_address_id, billing_address_id]:
+        if address_id:
+            addr = await session.get(Address, address_id)
+            if not addr or addr.user_id != current_user.id:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid address")
+
+    order = await order_service.build_order_from_cart(
+        session,
+        current_user.id,
+        cart,
+        shipping_address_id,
+        billing_address_id,
+    )
+    return order
+
+
+@router.get("", response_model=list[OrderRead])
+async def list_orders(current_user=Depends(get_current_user), session: AsyncSession = Depends(get_session)):
+    orders = await order_service.get_orders_for_user(session, current_user.id)
+    return list(orders)
+
+
+@router.get("/{order_id}", response_model=OrderRead)
+async def get_order(order_id: UUID, current_user=Depends(get_current_user), session: AsyncSession = Depends(get_session)):
+    order = await order_service.get_order(session, current_user.id, order_id)
+    if not order:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Order not found")
+    return order

--- a/backend/app/api/v1/routes.py
+++ b/backend/app/api/v1/routes.py
@@ -4,6 +4,7 @@ from app.api.v1 import auth
 from app.api.v1 import catalog
 from app.api.v1 import cart
 from app.api.v1 import addresses
+from app.api.v1 import orders
 
 api_router = APIRouter()
 
@@ -11,6 +12,7 @@ api_router.include_router(auth.router)
 api_router.include_router(catalog.router)
 api_router.include_router(cart.router)
 api_router.include_router(addresses.router)
+api_router.include_router(orders.router)
 
 
 @api_router.get("/health", tags=["health"])

--- a/backend/app/services/order.py
+++ b/backend/app/services/order.py
@@ -1,0 +1,70 @@
+from decimal import Decimal
+from typing import Sequence
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy.orm import selectinload
+
+from app.models.address import Address
+from app.models.cart import Cart, CartItem
+from app.models.order import Order, OrderItem
+
+
+async def build_order_from_cart(
+    session: AsyncSession,
+    user_id: UUID,
+    cart: Cart,
+    shipping_address_id: UUID | None,
+    billing_address_id: UUID | None,
+) -> Order:
+    if not cart.items:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cart is empty")
+
+    total = Decimal("0.00")
+    items: list[OrderItem] = []
+    for item in cart.items:
+        subtotal = Decimal(item.unit_price_at_add) * item.quantity
+        total += subtotal
+        items.append(
+            OrderItem(
+                product_id=item.product_id,
+                variant_id=item.variant_id,
+                quantity=item.quantity,
+                unit_price=item.unit_price_at_add,
+                subtotal=subtotal,
+            )
+        )
+
+    order = Order(
+        user_id=user_id,
+        total_amount=total,
+        currency="USD",
+        shipping_address_id=shipping_address_id,
+        billing_address_id=billing_address_id,
+        items=items,
+    )
+    session.add(order)
+    await session.commit()
+    await session.refresh(order)
+    return order
+
+
+async def get_orders_for_user(session: AsyncSession, user_id: UUID) -> Sequence[Order]:
+    result = await session.execute(
+        select(Order)
+        .where(Order.user_id == user_id)
+        .options(selectinload(Order.items))
+        .order_by(Order.created_at.desc())
+    )
+    return result.scalars().all()
+
+
+async def get_order(session: AsyncSession, user_id: UUID, order_id: UUID) -> Order | None:
+    result = await session.execute(
+        select(Order)
+            .where(Order.user_id == user_id, Order.id == order_id)
+            .options(selectinload(Order.items))
+    )
+    return result.scalar_one_or_none()


### PR DESCRIPTION
**Summary**
- Add service to build orders from cart items with price snapshots and expose user order endpoints.
- Allow users to create an order from their cart and list/view their orders.
- Update TODO backlog for order service/endpoints.

**Changes**
- Added order builder service and `/api/v1/orders` endpoints: create (from cart with address validation), list, and detail for the current user.
- Wired orders router; updated TODO for order service and user order endpoints.

**Testing**
- `cd backend && . .venv/bin/activate && python -m pytest -q`

**Risk & Impact**
- Low: additive endpoints and services; payment/Stripe still pending.

**Related TODO items**
- [x] Service to build order from cart (price snapshot).
- [x] GET /me/orders and /me/orders/{id}.