### PR TITLE
feat: add tags, options, reviews, and product duplication

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -42,12 +42,12 @@ Below is a structured checklist you can turn into issues.
 - [x] Product status enums (draft/published/archived).
 - [x] Track publish date and last_modified.
 - [x] Bulk price/stock update endpoint for admins.
-- [ ] Product labels/tags schema and filters.
-- [ ] Product option schema (color/size) without variants.
-- [ ] Admin product duplication/cloning.
-- [ ] Product reviews model + moderation queue.
-- [ ] Average rating + review count on product list/detail.
-- [ ] Related products/recommendations service (rule-based).
+- [x] Product labels/tags schema and filters.
+- [x] Product option schema (color/size) without variants.
+- [x] Admin product duplication/cloning.
+- [x] Product reviews model + moderation queue.
+- [x] Average rating + review count on product list/detail.
+- [x] Related products/recommendations service (rule-based).
 - [ ] Recently viewed products service (per session).
 - [ ] Admin export products CSV.
 - [ ] Admin import products CSV with dry-run validation.

--- a/backend/alembic/versions/0009_product_tags_reviews_options.py
+++ b/backend/alembic/versions/0009_product_tags_reviews_options.py
@@ -1,0 +1,78 @@
+"""product tags, options, reviews, rating fields
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2024-10-05
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0009"
+down_revision: str | None = "0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tags",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.Column("slug", sa.String(length=80), nullable=False),
+        sa.UniqueConstraint("name", name="uq_tags_name"),
+        sa.UniqueConstraint("slug", name="uq_tags_slug"),
+    )
+    op.create_index("ix_tags_name", "tags", ["name"], unique=True)
+    op.create_index("ix_tags_slug", "tags", ["slug"], unique=True)
+
+    op.create_table(
+        "product_options",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("product_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("products.id"), nullable=False),
+        sa.Column("option_name", sa.String(length=50), nullable=False),
+        sa.Column("option_value", sa.String(length=120), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "product_reviews",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("product_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("products.id"), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=True),
+        sa.Column("author_name", sa.String(length=160), nullable=False),
+        sa.Column("rating", sa.Integer(), nullable=False),
+        sa.Column("title", sa.String(length=160), nullable=True),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("is_approved", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.add_column(
+        "products",
+        sa.Column("rating_average", sa.Numeric(3, 2), nullable=False, server_default="0"),
+    )
+    op.add_column("products", sa.Column("rating_count", sa.Integer(), nullable=False, server_default="0"))
+    op.alter_column("products", "rating_average", server_default=None)
+    op.alter_column("products", "rating_count", server_default=None)
+
+    op.create_table(
+        "product_tags",
+        sa.Column("product_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("products.id"), primary_key=True),
+        sa.Column("tag_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("tags.id"), primary_key=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("product_tags")
+    op.drop_column("products", "rating_count")
+    op.drop_column("products", "rating_average")
+    op.drop_table("product_reviews")
+    op.drop_table("product_options")
+    op.drop_index("ix_tags_slug", table_name="tags")
+    op.drop_index("ix_tags_name", table_name="tags")
+    op.drop_table("tags")

--- a/backend/app/api/v1/catalog.py
+++ b/backend/app/api/v1/catalog.py
@@ -5,9 +5,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import selectinload
 
-from app.core.dependencies import get_current_user, require_admin
+from app.core.dependencies import require_admin, get_current_user_optional
 from app.db.session import get_session
-from app.models.catalog import Category, Product
+from app.models.catalog import Category, Product, Tag, ProductReview
 from app.schemas.catalog import (
     CategoryCreate,
     CategoryRead,
@@ -15,6 +15,8 @@ from app.schemas.catalog import (
     ProductCreate,
     ProductRead,
     ProductUpdate,
+    ProductReviewCreate,
+    ProductReviewRead,
     BulkProductUpdateItem,
 )
 from app.services import catalog as catalog_service
@@ -37,10 +39,16 @@ async def list_products(
     search: str | None = Query(default=None),
     min_price: float | None = Query(default=None, ge=0),
     max_price: float | None = Query(default=None, ge=0),
+    tags: list[str] | None = Query(default=None),
+    sort: str | None = Query(default=None, description="newest|price_asc|price_desc|name_asc|name_desc"),
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
 ) -> list[Product]:
-    query = select(Product).options(selectinload(Product.images), selectinload(Product.category))
+    query = select(Product).options(
+        selectinload(Product.images),
+        selectinload(Product.category),
+        selectinload(Product.tags),
+    )
     query = query.where(Product.is_deleted.is_(False))
     if category_slug:
         query = query.join(Category).where(Category.slug == category_slug)
@@ -55,7 +63,19 @@ async def list_products(
         query = query.where(Product.base_price >= min_price)
     if max_price is not None:
         query = query.where(Product.base_price <= max_price)
-    result = await session.execute(query.order_by(Product.created_at.desc()).limit(limit).offset(offset))
+    if tags:
+        query = query.join(Product.tags).where(Tag.slug.in_(tags))
+    if sort == "price_asc":
+        query = query.order_by(Product.base_price.asc())
+    elif sort == "price_desc":
+        query = query.order_by(Product.base_price.desc())
+    elif sort == "name_asc":
+        query = query.order_by(Product.name.asc())
+    elif sort == "name_desc":
+        query = query.order_by(Product.name.desc())
+    else:
+        query = query.order_by(Product.created_at.desc())
+    result = await session.execute(query.limit(limit).offset(offset))
     return list(result.scalars().unique())
 
 
@@ -164,6 +184,21 @@ async def bulk_update_products(
     return updated
 
 
+@router.post("/products/{slug}/duplicate", response_model=ProductRead, status_code=status.HTTP_201_CREATED)
+async def duplicate_product(
+    slug: str,
+    session: AsyncSession = Depends(get_session),
+    _: str = Depends(require_admin),
+) -> Product:
+    product = await catalog_service.get_product_by_slug(
+        session, slug, options=[selectinload(Product.images), selectinload(Product.category), selectinload(Product.options)]
+    )
+    if not product or product.is_deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    clone = await catalog_service.duplicate_product(session, product)
+    return clone
+
+
 @router.delete("/products/{slug}/images/{image_id}", response_model=ProductRead)
 async def delete_product_image(
     slug: str,
@@ -180,3 +215,48 @@ async def delete_product_image(
     await catalog_service.delete_product_image(session, product, image_id)
     await session.refresh(product)
     return product
+
+
+@router.post("/products/{slug}/reviews", response_model=ProductReviewRead, status_code=status.HTTP_201_CREATED)
+async def create_review(
+    slug: str,
+    payload: ProductReviewCreate,
+    session: AsyncSession = Depends(get_session),
+    current_user=Depends(get_current_user_optional),
+) -> ProductReviewRead:
+    product = await catalog_service.get_product_by_slug(session, slug)
+    if not product or product.is_deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    review = await catalog_service.add_review(session, product, payload, getattr(current_user, "id", None) if current_user else None)
+    return review
+
+
+@router.post("/products/{slug}/reviews/{review_id}/approve", response_model=ProductReviewRead)
+async def approve_review(
+    slug: str,
+    review_id: UUID,
+    session: AsyncSession = Depends(get_session),
+    _: str = Depends(require_admin),
+) -> ProductReviewRead:
+    product = await catalog_service.get_product_by_slug(session, slug)
+    if not product:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    result = await session.execute(
+        select(ProductReview).where(ProductReview.id == review_id, ProductReview.product_id == product.id)
+    )
+    review = result.scalar_one_or_none()
+    if not review:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Review not found")
+    review = await catalog_service.approve_review(session, review)
+    return review
+
+
+@router.get("/products/{slug}/related", response_model=list[ProductRead])
+async def related_products(slug: str, session: AsyncSession = Depends(get_session)) -> list[Product]:
+    product = await catalog_service.get_product_by_slug(
+        session, slug, options=[selectinload(Product.images), selectinload(Product.category)]
+    )
+    if not product or product.is_deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    related = await catalog_service.get_related_products(session, product, limit=4)
+    return related

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,14 @@
 from app.db.base import Base  # noqa: F401
 from app.models.user import User  # noqa: F401
-from app.models.catalog import Category, Product, ProductImage, ProductVariant  # noqa: F401
+from app.models.catalog import (
+    Category,
+    Product,
+    ProductImage,
+    ProductVariant,
+    ProductOption,
+    Tag,
+    ProductReview,
+)  # noqa: F401
 from app.models.cart import Cart, CartItem  # noqa: F401
 from app.models.address import Address  # noqa: F401
 from app.models.order import Order, OrderItem  # noqa: F401
@@ -12,6 +20,9 @@ __all__ = [
     "Product",
     "ProductImage",
     "ProductVariant",
+    "ProductOption",
+    "ProductReview",
+    "Tag",
     "Cart",
     "CartItem",
     "Address",

--- a/backend/app/schemas/catalog.py
+++ b/backend/app/schemas/catalog.py
@@ -43,27 +43,6 @@ class ProductBase(BaseModel):
     stock_quantity: int = Field(ge=0)
 
 
-class ProductCreate(ProductBase):
-    images: list["ProductImageCreate"] = []
-    variants: list["ProductVariantCreate"] = []
-    status: ProductStatus = ProductStatus.draft
-
-
-class ProductUpdate(BaseModel):
-    name: str | None = Field(default=None, max_length=160)
-    short_description: str | None = Field(default=None, max_length=280)
-    long_description: str | None = None
-    base_price: float | None = Field(default=None, ge=0)
-    currency: str | None = Field(default=None, min_length=3, max_length=3)
-    is_active: bool | None = None
-    is_featured: bool | None = None
-    stock_quantity: int | None = Field(default=None, ge=0)
-    category_id: UUID | None = None
-    sku: str | None = Field(default=None, min_length=3, max_length=64)
-    status: ProductStatus | None = None
-    publish_at: datetime | None = None
-
-
 class ProductImageBase(BaseModel):
     url: str
     alt_text: str | None = None
@@ -96,6 +75,76 @@ class ProductVariantRead(ProductVariantBase):
     id: UUID
 
 
+class ProductOptionBase(BaseModel):
+    option_name: str
+    option_value: str
+
+
+class ProductOptionCreate(ProductOptionBase):
+    pass
+
+
+class ProductOptionRead(ProductOptionBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+
+
+class TagRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    slug: str
+
+
+class ProductReviewCreate(BaseModel):
+    author_name: str
+    rating: int = Field(ge=1, le=5)
+    title: str | None = None
+    body: str | None = None
+
+
+class ProductReviewRead(ProductReviewCreate):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    is_approved: bool
+    created_at: datetime
+
+
+class ProductCreate(ProductBase):
+    images: list[ProductImageCreate] = []
+    variants: list[ProductVariantCreate] = []
+    tags: list[str] = []
+    options: list[ProductOptionCreate] = []
+    status: ProductStatus = ProductStatus.draft
+
+
+class ProductUpdate(BaseModel):
+    name: str | None = Field(default=None, max_length=160)
+    short_description: str | None = Field(default=None, max_length=280)
+    long_description: str | None = None
+    base_price: float | None = Field(default=None, ge=0)
+    currency: str | None = Field(default=None, min_length=3, max_length=3)
+    is_active: bool | None = None
+    is_featured: bool | None = None
+    stock_quantity: int | None = Field(default=None, ge=0)
+    category_id: UUID | None = None
+    sku: str | None = Field(default=None, min_length=3, max_length=64)
+    status: ProductStatus | None = None
+    publish_at: datetime | None = None
+    tags: list[str] | None = None
+    options: list[ProductOptionCreate] | None = None
+
+
+class BulkProductUpdateItem(BaseModel):
+    product_id: UUID
+    base_price: float | None = Field(default=None, ge=0)
+    stock_quantity: int | None = Field(default=None, ge=0)
+    status: ProductStatus | None = None
+
+
 class ProductRead(ProductBase):
     model_config = ConfigDict(from_attributes=True)
 
@@ -105,13 +154,11 @@ class ProductRead(ProductBase):
     publish_at: datetime | None = None
     last_modified: datetime
     status: ProductStatus
+    rating_average: float
+    rating_count: int
     images: list[ProductImageRead] = []
     category: CategoryRead
     variants: list[ProductVariantRead] = []
-
-
-class BulkProductUpdateItem(BaseModel):
-    product_id: UUID
-    base_price: float | None = Field(default=None, ge=0)
-    stock_quantity: int | None = Field(default=None, ge=0)
-    status: ProductStatus | None = None
+    options: list[ProductOptionRead] = []
+    tags: list[TagRead] = []
+    reviews: list[ProductReviewRead] = []

--- a/backend/app/services/catalog.py
+++ b/backend/app/services/catalog.py
@@ -1,22 +1,32 @@
 from datetime import datetime, timezone
-import uuid
 import random
 import string
+import uuid
 
 from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
-from sqlalchemy.orm import selectinload
 
-from app.models.catalog import Category, Product, ProductImage, ProductVariant, ProductStatus
+from app.models.catalog import (
+    Category,
+    Product,
+    ProductImage,
+    ProductOption,
+    ProductVariant,
+    ProductStatus,
+    Tag,
+    ProductReview,
+)
 from app.schemas.catalog import (
     CategoryCreate,
     CategoryUpdate,
-    BulkProductUpdateItem,
     ProductCreate,
     ProductImageCreate,
     ProductUpdate,
     ProductVariantCreate,
+    BulkProductUpdateItem,
+    ProductOptionCreate,
+    ProductReviewCreate,
 )
 from app.services.storage import delete_file
 
@@ -37,11 +47,6 @@ async def get_product_by_slug(
     return result.scalar_one_or_none()
 
 
-async def _get_product_by_sku(session: AsyncSession, sku: str) -> Product | None:
-    result = await session.execute(select(Product).where(Product.sku == sku))
-    return result.scalar_one_or_none()
-
-
 async def _ensure_slug_unique(session: AsyncSession, slug: str, exclude_id: uuid.UUID | None = None) -> None:
     query = select(Product).where(Product.slug == slug)
     if exclude_id:
@@ -49,6 +54,11 @@ async def _ensure_slug_unique(session: AsyncSession, slug: str, exclude_id: uuid
     exists = await session.execute(query)
     if exists.scalar_one_or_none():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Product slug already exists")
+
+
+async def _get_product_by_sku(session: AsyncSession, sku: str) -> Product | None:
+    result = await session.execute(select(Product).where(Product.sku == sku))
+    return result.scalar_one_or_none()
 
 
 async def _ensure_sku_unique(session: AsyncSession, sku: str, exclude_id: uuid.UUID | None = None) -> None:
@@ -61,20 +71,12 @@ async def _ensure_sku_unique(session: AsyncSession, sku: str, exclude_id: uuid.U
 
 
 async def _generate_unique_sku(session: AsyncSession, base: str) -> str:
-    slug_part = base.replace("-", "").upper()[:8]
+    slug_part = base.replace("-", "").upper()[:8] or "SKU"
     while True:
         suffix = "".join(random.choices(string.digits, k=4))
         candidate = f"{slug_part}-{suffix}"
         if not await _get_product_by_sku(session, candidate):
             return candidate
-
-
-def _set_publish_timestamp(product: Product, status_value: ProductStatus | str | None) -> None:
-    if not status_value:
-        return
-    status_enum = ProductStatus(status_value)
-    if status_enum == ProductStatus.published and product.publish_at is None:
-        product.publish_at = datetime.now(timezone.utc)
 
 
 async def create_category(session: AsyncSession, payload: CategoryCreate) -> Category:
@@ -99,18 +101,21 @@ async def update_category(session: AsyncSession, category: Category, payload: Ca
 
 async def create_product(session: AsyncSession, payload: ProductCreate) -> Product:
     await _ensure_slug_unique(session, payload.slug)
-
     sku = payload.sku or await _generate_unique_sku(session, payload.slug)
     await _ensure_sku_unique(session, sku)
 
     images_payload = payload.images or []
     variants_payload: list[ProductVariantCreate] = getattr(payload, "variants", []) or []
-    product_data = payload.model_dump(exclude={"images", "variants"})
+    product_data = payload.model_dump(exclude={"images", "variants", "tags", "options"})
     product_data["sku"] = sku
     product = Product(**product_data)
     _set_publish_timestamp(product, payload.status)
     product.images = [ProductImage(**img.model_dump()) for img in images_payload]
     product.variants = [ProductVariant(**variant.model_dump()) for variant in variants_payload]
+    if payload.tags:
+        product.tags = await _get_or_create_tags(session, payload.tags)
+    if payload.options:
+        product.options = [ProductOption(**opt.model_dump()) for opt in payload.options]
     session.add(product)
     await session.commit()
     await session.refresh(product)
@@ -123,6 +128,10 @@ async def update_product(session: AsyncSession, product: Product, payload: Produ
         await _ensure_slug_unique(session, data["slug"], exclude_id=product.id)
     if "sku" in data and data["sku"]:
         await _ensure_sku_unique(session, data["sku"], exclude_id=product.id)
+    if "tags" in data and data["tags"] is not None:
+        product.tags = await _get_or_create_tags(session, data["tags"])
+    if "options" in data and data["options"] is not None:
+        product.options = [ProductOption(**opt.model_dump()) for opt in data["options"]]
     for field, value in data.items():
         setattr(product, field, value)
     _set_publish_timestamp(product, data.get("status"))
@@ -187,3 +196,125 @@ async def bulk_update_products(session: AsyncSession, updates: list[BulkProductU
     for product in updated:
         await session.refresh(product)
     return updated
+
+
+def slugify(value: str) -> str:
+    cleaned = "".join(ch.lower() if ch.isalnum() else "-" for ch in value).strip("-")
+    return "-".join(filter(None, cleaned.split("-")))
+
+
+async def _get_or_create_tags(session: AsyncSession, names: list[str]) -> list[Tag]:
+    slugs = [slugify(name) for name in names]
+    result = await session.execute(select(Tag).where(Tag.slug.in_(slugs)))
+    existing = {tag.slug: tag for tag in result.scalars()}
+    tags: list[Tag] = []
+    for name, slug in zip(names, slugs):
+        if slug in existing:
+            tags.append(existing[slug])
+        else:
+            tag = Tag(name=name, slug=slug)
+            session.add(tag)
+            tags.append(tag)
+    await session.flush()
+    return tags
+
+
+async def duplicate_product(session: AsyncSession, product: Product) -> Product:
+    base_slug = f"{product.slug}-copy"
+    new_slug = base_slug
+    counter = 1
+    while await get_product_by_slug(session, new_slug):
+        counter += 1
+        new_slug = f"{base_slug}-{counter}"
+    new_sku = await _generate_unique_sku(session, new_slug)
+
+    clone = Product(
+        category_id=product.category_id,
+        sku=new_sku,
+        slug=new_slug,
+        name=f"{product.name} (Copy)",
+        short_description=product.short_description,
+        long_description=product.long_description,
+        base_price=product.base_price,
+        currency=product.currency,
+        is_active=False,
+        is_featured=False,
+        stock_quantity=product.stock_quantity,
+        status=ProductStatus.draft,
+    )
+    clone.images = [ProductImage(url=img.url, alt_text=img.alt_text, sort_order=img.sort_order) for img in product.images]
+    clone.variants = [
+        ProductVariant(name=variant.name, additional_price_delta=variant.additional_price_delta, stock_quantity=variant.stock_quantity)
+        for variant in product.variants
+    ]
+    clone.options = [ProductOption(option_name=opt.option_name, option_value=opt.option_value) for opt in product.options]
+    clone.tags = product.tags.copy()
+    session.add(clone)
+    await session.commit()
+    await session.refresh(clone)
+    return clone
+
+
+def _set_publish_timestamp(product: Product, status_value: ProductStatus | str | None) -> None:
+    if not status_value:
+        return
+    status_enum = ProductStatus(status_value)
+    if status_enum == ProductStatus.published and product.publish_at is None:
+        product.publish_at = datetime.now(timezone.utc)
+
+
+async def add_review(
+    session: AsyncSession, product: Product, payload: ProductReviewCreate, user_id: uuid.UUID | None
+) -> ProductReview:
+    review = ProductReview(
+        product=product,
+        user_id=user_id,
+        author_name=payload.author_name,
+        rating=payload.rating,
+        title=payload.title,
+        body=payload.body,
+        is_approved=False,
+    )
+    session.add(review)
+    await session.commit()
+    await session.refresh(review)
+    return review
+
+
+async def approve_review(session: AsyncSession, review: ProductReview) -> ProductReview:
+    review.is_approved = True
+    session.add(review)
+    await session.commit()
+    await session.refresh(review)
+    await recompute_product_rating(session, review.product_id)
+    return review
+
+
+async def recompute_product_rating(session: AsyncSession, product_id: uuid.UUID) -> None:
+    result = await session.execute(
+        select(ProductReview).where(ProductReview.product_id == product_id, ProductReview.is_approved.is_(True))
+    )
+    reviews = result.scalars().all()
+    count = len(reviews)
+    avg = sum(r.rating for r in reviews) / count if count else 0
+    product = await session.get(Product, product_id)
+    product.rating_average = avg
+    product.rating_count = count
+    session.add(product)
+    await session.commit()
+    await session.refresh(product)
+
+
+async def get_related_products(session: AsyncSession, product: Product, limit: int = 4):
+    result = await session.execute(
+        select(Product)
+        .where(
+            Product.category_id == product.category_id,
+            Product.id != product.id,
+            Product.is_deleted.is_(False),
+            Product.status == ProductStatus.published,
+        )
+        .order_by(Product.is_featured.desc(), Product.created_at.desc())
+        .limit(limit)
+    )
+    return result.scalars().unique().all()


### PR DESCRIPTION
**Summary**
- Extend catalog with tags, options, reviews/ratings, related products, and admin duplication/bulk updates.
- Add rating snapshot fields, tag/option schemas, and review moderation; generate SKUs when missing.
- Expand product list filters (tags, sort) and add related/reviews endpoints; update TODO entries.

**Changes**
- Added models & migration (0009) for tags, product_options, product_reviews, rating fields, and tag join table.
- Catalog services now handle slug/SKU uniqueness, tag creation, options, review creation/approval with rating recompute, product duplication, and related products lookup.
- APIs: product list supports tags/sort; admin bulk update and duplicate endpoints; review create/approve endpoints; related products endpoint.
- Schemas/tests updated for new fields and filters; TODO marks completed tasks.

**Testing**
- `cd backend && . .venv/bin/activate && python -m pytest -q`

**Risk & Impact**
- Medium: schema changes and new endpoints; defaults/backfills included for SKU/rating fields; review approval currently manual.

**Related TODO items**
- [x] Product labels/tags schema and filters.
- [x] Product option schema (color/size) without variants.
- [x] Admin product duplication/cloning.
- [x] Product reviews model + moderation queue.
- [x] Average rating + review count on product list/detail.
- [x] Related products/recommendations service (rule-based).