### PR TITLE
feat: add content blocks and versioning

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,11 +105,11 @@ Below is a structured checklist you can turn into issues.
 - [x] Address validation hook (country/postal rules).
 
 ## Backend - CMS & Content
-- [ ] ContentBlock model + migration.
-- [ ] Seed default blocks (home hero, about, FAQ, shipping/returns, care).
-- [ ] GET /content/{key} public.
-- [ ] Admin edit content blocks; validate markdown/HTML safety.
-- [ ] Content versioning with draft/publish states.
+- [x] ContentBlock model + migration.
+- [x] Seed default blocks (home hero, about, FAQ, shipping/returns, care).
+- [x] GET /content/{key} public.
+- [x] Admin edit content blocks; validate markdown/HTML safety.
+- [x] Content versioning with draft/publish states.
 - [ ] Image uploads for content blocks.
 - [ ] Rich text sanitization rules.
 - [ ] Homepage layout blocks (hero, grid, testimonials).

--- a/backend/alembic/versions/0017_content_blocks.py
+++ b/backend/alembic/versions/0017_content_blocks.py
@@ -1,0 +1,98 @@
+"""content blocks and versions
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2024-10-09
+"""
+
+from collections.abc import Sequence
+import uuid
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0017"
+down_revision: str | None = "0016"
+branch_labels: str | Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    content_status = sa.Enum("draft", "published", name="contentstatus")
+    content_status.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "content_blocks",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("key", sa.String(length=120), nullable=False, unique=True, index=True),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("body_markdown", sa.Text(), nullable=False),
+        sa.Column("status", content_status, nullable=False, server_default="draft"),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    op.create_table(
+        "content_block_versions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("content_block_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("content_blocks.id"), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("body_markdown", sa.Text(), nullable=False),
+        sa.Column("status", content_status, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    # Seed default blocks
+    now = datetime.now(timezone.utc)
+    defaults = [
+        ("home.hero", "Welcome to AdrianaArt", "Handmade art for your home", now),
+        ("page.about", "About Us", "Story about AdrianaArt.", now),
+        ("page.faq", "FAQ", "Frequently asked questions.", now),
+        ("page.shipping", "Shipping & Returns", "Shipping and return policies.", now),
+        ("page.care", "Care Instructions", "How to care for your items.", now),
+    ]
+    # Use explicit inserts for compatibility
+    connection = op.get_bind()
+    for key, title, body, ts in defaults:
+        block_id = str(uuid.uuid4())
+        version = 1
+        connection.execute(
+            sa.text(
+                "INSERT INTO content_blocks (id, key, title, body_markdown, status, version, published_at, created_at, updated_at) "
+                "VALUES (:id, :key, :title, :body, 'published', :version, :published_at, :created_at, :created_at)"
+            ),
+            {"id": block_id, "key": key, "title": title, "body": body, "version": version, "published_at": ts, "created_at": ts},
+        )
+        connection.execute(
+            sa.text(
+                "INSERT INTO content_block_versions (id, content_block_id, version, title, body_markdown, status, created_at) "
+                "VALUES (:vid, :bid, :version, :title, :body, 'published', :created_at)"
+            ),
+            {
+                "vid": str(uuid.uuid4()),
+                "bid": block_id,
+                "version": version,
+                "title": title,
+                "body": body,
+                "created_at": ts,
+            },
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("content_block_versions")
+    op.drop_table("content_blocks")
+    content_status = sa.Enum("draft", "published", name="contentstatus")
+    content_status.drop(op.get_bind(), checkfirst=True)

--- a/backend/app/api/v1/content.py
+++ b/backend/app/api/v1/content.py
@@ -1,0 +1,55 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import get_session, require_admin
+from app.schemas.content import ContentBlockRead, ContentBlockUpdate, ContentBlockCreate
+from app.services import content as content_service
+
+router = APIRouter(prefix="/content", tags=["content"])
+
+
+@router.get("/{key}", response_model=ContentBlockRead)
+async def get_content(key: str, session: AsyncSession = Depends(get_session)) -> ContentBlockRead:
+    block = await content_service.get_published_by_key(session, key)
+    if not block:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Content not found")
+    return block
+
+
+@router.get("/admin/{key}", response_model=ContentBlockRead)
+async def admin_get_content(
+    key: str,
+    session: AsyncSession = Depends(get_session),
+    _: str = Depends(require_admin),
+) -> ContentBlockRead:
+    block = await content_service.get_block_by_key(session, key)
+    if not block:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Content not found")
+    return block
+
+
+@router.patch("/admin/{key}", response_model=ContentBlockRead)
+async def admin_update_content(
+    key: str,
+    payload: ContentBlockUpdate,
+    session: AsyncSession = Depends(get_session),
+    _: str = Depends(require_admin),
+) -> ContentBlockRead:
+    block = await content_service.upsert_block(session, key, payload)
+    return block
+
+
+@router.post("/admin/{key}", response_model=ContentBlockRead, status_code=status.HTTP_201_CREATED)
+async def admin_create_content(
+    key: str,
+    payload: ContentBlockCreate,
+    session: AsyncSession = Depends(get_session),
+    _: str = Depends(require_admin),
+) -> ContentBlockRead:
+    existing = await content_service.get_block_by_key(session, key)
+    if existing:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Content key exists")
+    block = await content_service.upsert_block(session, key, payload)
+    return block

--- a/backend/app/api/v1/routes.py
+++ b/backend/app/api/v1/routes.py
@@ -6,6 +6,7 @@ from app.api.v1 import cart
 from app.api.v1 import addresses
 from app.api.v1 import orders
 from app.api.v1 import payments
+from app.api.v1 import content
 
 api_router = APIRouter()
 
@@ -15,6 +16,7 @@ api_router.include_router(cart.router)
 api_router.include_router(addresses.router)
 api_router.include_router(orders.router)
 api_router.include_router(payments.router)
+api_router.include_router(content.router)
 
 
 @api_router.get("/health", tags=["health"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -17,6 +17,7 @@ from app.models.cart import Cart, CartItem  # noqa: F401
 from app.models.promo import PromoCode  # noqa: F401
 from app.models.address import Address  # noqa: F401
 from app.models.order import Order, OrderItem, OrderStatus, ShippingMethod, OrderEvent  # noqa: F401
+from app.models.content import ContentBlock, ContentBlockVersion, ContentStatus  # noqa: F401
 
 __all__ = [
     "Base",
@@ -40,4 +41,7 @@ __all__ = [
     "OrderStatus",
     "ShippingMethod",
     "OrderEvent",
+    "ContentBlock",
+    "ContentBlockVersion",
+    "ContentStatus",
 ]

--- a/backend/app/models/content.py
+++ b/backend/app/models/content.py
@@ -1,0 +1,48 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, ForeignKey, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class ContentStatus(str, enum.Enum):
+    draft = "draft"
+    published = "published"
+
+
+class ContentBlock(Base):
+    __tablename__ = "content_blocks"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    key: Mapped[str] = mapped_column(String(120), unique=True, nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    body_markdown: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[ContentStatus] = mapped_column(Enum(ContentStatus), nullable=False, default=ContentStatus.draft)
+    version: Mapped[int] = mapped_column(nullable=False, default=1)
+    published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    versions: Mapped[list["ContentBlockVersion"]] = relationship(
+        "ContentBlockVersion", back_populates="block", cascade="all, delete-orphan", lazy="selectin"
+    )
+
+
+class ContentBlockVersion(Base):
+    __tablename__ = "content_block_versions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    content_block_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("content_blocks.id"), nullable=False)
+    version: Mapped[int] = mapped_column(nullable=False)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    body_markdown: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[ContentStatus] = mapped_column(Enum(ContentStatus), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    block: Mapped[ContentBlock] = relationship("ContentBlock", back_populates="versions")

--- a/backend/app/schemas/content.py
+++ b/backend/app/schemas/content.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.models.content import ContentStatus
+
+
+class ContentBlockBase(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+    body_markdown: str = Field(min_length=1)
+    status: ContentStatus = ContentStatus.draft
+
+    @field_validator("body_markdown")
+    @classmethod
+    def _validate_markdown(cls, body: str) -> str:
+        if "<script" in body.lower():
+            raise ValueError("Script tags are not allowed")
+        return body
+
+
+class ContentBlockCreate(ContentBlockBase):
+    pass
+
+
+class ContentBlockUpdate(BaseModel):
+    title: str | None = Field(default=None, max_length=200)
+    body_markdown: str | None = Field(default=None)
+    status: ContentStatus | None = None
+
+    @field_validator("body_markdown")
+    @classmethod
+    def _validate_markdown(cls, body: str | None) -> str | None:
+        if body and "<script" in body.lower():
+            raise ValueError("Script tags are not allowed")
+        return body
+
+
+class ContentBlockRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    key: str
+    title: str
+    body_markdown: str
+    status: ContentStatus
+    version: int
+    published_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/content.py
+++ b/backend/app/services/content.py
@@ -1,0 +1,73 @@
+from datetime import datetime, timezone
+
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.models.content import ContentBlock, ContentBlockVersion, ContentStatus
+from app.schemas.content import ContentBlockCreate, ContentBlockUpdate
+
+
+async def get_published_by_key(session: AsyncSession, key: str) -> ContentBlock | None:
+    result = await session.execute(
+        select(ContentBlock).where(ContentBlock.key == key, ContentBlock.status == ContentStatus.published)
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_block_by_key(session: AsyncSession, key: str) -> ContentBlock | None:
+    result = await session.execute(select(ContentBlock).where(ContentBlock.key == key))
+    return result.scalar_one_or_none()
+
+
+async def upsert_block(session: AsyncSession, key: str, payload: ContentBlockUpdate | ContentBlockCreate) -> ContentBlock:
+    block = await get_block_by_key(session, key)
+    now = datetime.now(timezone.utc)
+    if not block:
+        data = payload.model_dump()
+        block = ContentBlock(
+            key=key,
+            title=data.get("title") or "",
+            body_markdown=data.get("body_markdown") or "",
+            status=data.get("status") or ContentStatus.draft,
+            version=1,
+            published_at=now if data.get("status") == ContentStatus.published else None,
+        )
+        session.add(block)
+        await session.flush()
+        version_row = ContentBlockVersion(
+            content_block_id=block.id,
+            version=block.version,
+            title=block.title,
+            body_markdown=block.body_markdown,
+            status=block.status,
+        )
+        session.add(version_row)
+        await session.commit()
+        await session.refresh(block)
+        return block
+
+    data = payload.model_dump(exclude_unset=True)
+    if not data:
+        return block
+    block.version += 1
+    if "title" in data:
+        block.title = data["title"] or block.title
+    if "body_markdown" in data and data["body_markdown"] is not None:
+        block.body_markdown = data["body_markdown"]
+    if "status" in data and data["status"] is not None:
+        block.status = data["status"]
+        if block.status == ContentStatus.published:
+            block.published_at = now
+    session.add(block)
+    version_row = ContentBlockVersion(
+        content_block_id=block.id,
+        version=block.version,
+        title=block.title,
+        body_markdown=block.body_markdown,
+        status=block.status,
+    )
+    session.add(version_row)
+    await session.commit()
+    await session.refresh(block)
+    return block

--- a/backend/tests/test_content_api.py
+++ b/backend/tests/test_content_api.py
@@ -1,0 +1,96 @@
+import asyncio
+from typing import Dict
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.main import app
+from app.db.base import Base
+from app.db.session import get_session
+from app.schemas.user import UserCreate
+from app.services.auth import create_user, issue_tokens_for_user
+from app.models.user import UserRole
+
+
+@pytest.fixture
+def test_app() -> Dict[str, object]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def init_models() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(init_models())
+
+    async def override_get_session():
+        async with SessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    client = TestClient(app)
+    yield {"client": client, "session_factory": SessionLocal}
+    client.close()
+    app.dependency_overrides.clear()
+
+
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def create_admin_token(session_factory) -> str:
+    async def create_and_token():
+        async with session_factory() as session:
+            user = await create_user(session, UserCreate(email="cms@example.com", password="cmspassword", name="CMS"))
+            user.role = UserRole.admin
+            await session.commit()
+            return issue_tokens_for_user(user)["access_token"]
+
+    return asyncio.run(create_and_token())
+
+
+def test_content_crud_and_public(test_app: Dict[str, object]) -> None:
+    client: TestClient = test_app["client"]  # type: ignore[assignment]
+    SessionLocal = test_app["session_factory"]  # type: ignore[assignment]
+    admin_token = create_admin_token(SessionLocal)
+
+    # Create
+    create = client.post(
+        "/api/v1/content/admin/home.hero",
+        json={"title": "Hero", "body_markdown": "Welcome!", "status": "published"},
+        headers=auth_headers(admin_token),
+    )
+    assert create.status_code == 201, create.text
+    assert create.json()["version"] == 1
+
+    public = client.get("/api/v1/content/home.hero")
+    assert public.status_code == 200
+    assert public.json()["title"] == "Hero"
+
+    # Update increments version
+    update = client.patch(
+        "/api/v1/content/admin/home.hero",
+        json={"body_markdown": "Updated body", "status": "published"},
+        headers=auth_headers(admin_token),
+    )
+    assert update.status_code == 200
+    assert update.json()["version"] == 2
+    assert update.json()["body_markdown"] == "Updated body"
+
+    # Validation rejects script
+    bad = client.patch(
+        "/api/v1/content/admin/home.hero",
+        json={"body_markdown": "<script>alert(1)</script>"},
+        headers=auth_headers(admin_token),
+    )
+    assert bad.status_code == 422
+
+    # Draft not visible publicly
+    client.patch(
+        "/api/v1/content/admin/page.about",
+        json={"title": "About", "body_markdown": "Draft only", "status": "draft"},
+        headers=auth_headers(admin_token),
+    )
+    missing = client.get("/api/v1/content/page.about")
+    assert missing.status_code == 404


### PR DESCRIPTION
- **Summary**
  - Introduce CMS content blocks with versioning, seeding defaults, and public/admin APIs.
- **Changes**
  - Added ContentBlock/ContentBlockVersion models and Alembic migration seeding hero/about/faq/shipping/care blocks.
  - Public GET `/content/{key}` and admin CRUD endpoints with markdown safety checks; content service handles version bumps and publishing timestamps.
  - New content schemas/tests plus router registration; tests cover create/update/publish, validation, and public visibility.
- **Testing**
  - `PYTHONPATH=backend DATABASE_URL=sqlite+aiosqlite:///:memory: .venv/bin/python -m pytest -q`
- **Risk & Impact**
  - Requires running migration 0017; markdown is minimally sanitized (scripts blocked).
- **Related TODO items**
  - [x] ContentBlock model + migration.
  - [x] Seed default blocks (home hero, about, FAQ, shipping/returns, care).
  - [x] GET /content/{key} public.
  - [x] Admin edit content blocks; validate markdown/HTML safety.
  - [x] Content versioning with draft/publish states.