### PR TITLE
feat: add content audit logging and email service

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -114,19 +114,14 @@ Below is a structured checklist you can turn into issues.
 - [x] Rich text sanitization rules.
 - [x] Homepage layout blocks (hero, grid, testimonials).
 - [x] FAQ ordering/priorities.
-- [x] Admin preview endpoint with token
-- [ ] Image uploads for content blocks.
-- [ ] Rich text sanitization rules.
-- [ ] Homepage layout blocks (hero, grid, testimonials).
-- [ ] FAQ ordering/priorities.
-- [ ] Admin preview endpoint with token.
-- [ ] Content change audit log.
-- [ ] Static page slugs for SEO (about/faq/shipping/returns/care).
+- [x] Admin preview endpoint with token.
+- [x] Content change audit log.
+- [x] Static page slugs for SEO (about/faq/shipping/returns/care).
 
 ## Backend - Email & Notifications
-- [ ] Email settings (SMTP).
-- [ ] Generic email service (text + HTML).
-- [ ] Order confirmation email.
+- [x] Email settings (SMTP).
+- [x] Generic email service (text + HTML).
+- [x] Order confirmation email.
 - [ ] Password reset email + one-time token flow.
 - [ ] Logging/error handling around email sending.
 - [ ] Background task for sending emails.

--- a/backend/alembic/versions/0019_content_audit_log.py
+++ b/backend/alembic/versions/0019_content_audit_log.py
@@ -1,0 +1,33 @@
+"""content audit log
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2024-10-10
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0019"
+down_revision: str | None = "0018"
+branch_labels: str | Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "content_audit_log",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("content_block_id", sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey("content_blocks.id"), nullable=False),
+        sa.Column("action", sa.String(length=120), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("content_audit_log")

--- a/backend/app/api/v1/content.py
+++ b/backend/app/api/v1/content.py
@@ -1,14 +1,26 @@
-from uuid import UUID
-
 from fastapi import APIRouter, Depends, HTTPException, status, File, UploadFile, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_session, require_admin
-from app.schemas.content import ContentBlockRead, ContentBlockUpdate, ContentBlockCreate
-from app.services import content as content_service
 from app.core.config import settings
+from app.core.dependencies import get_session, require_admin
+from app.schemas.content import (
+    ContentAuditRead,
+    ContentBlockCreate,
+    ContentBlockRead,
+    ContentBlockUpdate,
+)
+from app.services import content as content_service
 
 router = APIRouter(prefix="/content", tags=["content"])
+
+
+@router.get("/pages/{slug}", response_model=ContentBlockRead)
+async def get_static_page(slug: str, session: AsyncSession = Depends(get_session)) -> ContentBlockRead:
+    key = f"page.{slug}"
+    block = await content_service.get_published_by_key(session, key)
+    if not block:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Content not found")
+    return block
 
 
 @router.get("/{key}", response_model=ContentBlockRead)
@@ -36,9 +48,9 @@ async def admin_update_content(
     key: str,
     payload: ContentBlockUpdate,
     session: AsyncSession = Depends(get_session),
-    _: str = Depends(require_admin),
+    admin=Depends(require_admin),
 ) -> ContentBlockRead:
-    block = await content_service.upsert_block(session, key, payload)
+    block = await content_service.upsert_block(session, key, payload, actor_id=admin.id)
     return block
 
 
@@ -47,12 +59,12 @@ async def admin_create_content(
     key: str,
     payload: ContentBlockCreate,
     session: AsyncSession = Depends(get_session),
-    _: str = Depends(require_admin),
+    admin=Depends(require_admin),
 ) -> ContentBlockRead:
     existing = await content_service.get_block_by_key(session, key)
     if existing:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Content key exists")
-    block = await content_service.upsert_block(session, key, payload)
+    block = await content_service.upsert_block(session, key, payload, actor_id=admin.id)
     return block
 
 
@@ -61,12 +73,12 @@ async def admin_upload_content_image(
     key: str,
     file: UploadFile = File(...),
     session: AsyncSession = Depends(get_session),
-    _: str = Depends(require_admin),
+    admin=Depends(require_admin),
 ) -> ContentBlockRead:
     block = await content_service.get_block_by_key(session, key)
     if not block:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Content not found")
-    block = await content_service.add_image(session, block, file)
+    block = await content_service.add_image(session, block, file, actor_id=admin.id)
     return block
 
 
@@ -82,3 +94,15 @@ async def admin_preview_content(
     if not block:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Content not found")
     return block
+
+
+@router.get("/admin/{key}/audit", response_model=list[ContentAuditRead])
+async def admin_list_content_audit(
+    key: str,
+    session: AsyncSession = Depends(get_session),
+    _: str = Depends(require_admin),
+) -> list[ContentAuditRead]:
+    block = await content_service.get_block_by_key(session, key)
+    if not block:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Content not found")
+    return block.audits

--- a/backend/app/api/v1/orders.py
+++ b/backend/app/api/v1/orders.py
@@ -17,6 +17,7 @@ from app.schemas.cart import CartRead
 from app.schemas.order import OrderRead, OrderCreate, OrderUpdate, ShippingMethodCreate, ShippingMethodRead, OrderEventRead
 from app.services import cart as cart_service
 from app.services import order as order_service
+from app.services import email as email_service
 
 router = APIRouter(prefix="/orders", tags=["orders"])
 
@@ -54,6 +55,7 @@ async def create_order(
         payload.billing_address_id,
         shipping_method,
     )
+    await email_service.send_order_confirmation(current_user.email, order, order.items)
     return order
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -30,6 +30,9 @@ class Settings(BaseSettings):
     smtp_port: int = 1025
     smtp_username: str | None = None
     smtp_password: str | None = None
+    smtp_enabled: bool = False
+    smtp_use_tls: bool = False
+    smtp_from_email: str | None = None
 
     frontend_origin: str = "http://localhost:4200"
     content_preview_token: str = "preview-token"

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -17,7 +17,7 @@ from app.models.cart import Cart, CartItem  # noqa: F401
 from app.models.promo import PromoCode  # noqa: F401
 from app.models.address import Address  # noqa: F401
 from app.models.order import Order, OrderItem, OrderStatus, ShippingMethod, OrderEvent  # noqa: F401
-from app.models.content import ContentBlock, ContentBlockVersion, ContentStatus, ContentImage  # noqa: F401
+from app.models.content import ContentBlock, ContentBlockVersion, ContentStatus, ContentImage, ContentAuditLog  # noqa: F401
 
 __all__ = [
     "Base",
@@ -45,4 +45,5 @@ __all__ = [
     "ContentBlockVersion",
     "ContentStatus",
     "ContentImage",
+    "ContentAuditLog",
 ]

--- a/backend/app/schemas/content.py
+++ b/backend/app/schemas/content.py
@@ -30,6 +30,8 @@ class ContentBlockUpdate(BaseModel):
     title: str | None = Field(default=None, max_length=200)
     body_markdown: str | None = Field(default=None)
     status: ContentStatus | None = None
+    meta: dict[str, Any] | None = None
+    sort_order: int | None = None
 
     @field_validator("body_markdown")
     @classmethod
@@ -53,15 +55,26 @@ class ContentBlockRead(BaseModel):
     created_at: datetime
     updated_at: datetime
     images: list["ContentImageRead"] = Field(default_factory=list)
+    audits: list["ContentAuditRead"] = Field(default_factory=list)
 
 
 class ContentImageRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    id: str | UUID
+    id: UUID
     url: str
     alt_text: str | None = None
     sort_order: int
+
+
+class ContentAuditRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    action: str
+    version: int
+    user_id: UUID | None = None
+    created_at: datetime
 
 
 ContentBlockRead.model_rebuild()

--- a/backend/app/services/content.py
+++ b/backend/app/services/content.py
@@ -1,28 +1,44 @@
 from datetime import datetime, timezone
+from uuid import UUID
+import re
 
 from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
-import re
+from sqlalchemy.orm import selectinload
 
-from app.models.content import ContentBlock, ContentBlockVersion, ContentStatus, ContentImage
+from app.models.content import (
+    ContentAuditLog,
+    ContentBlock,
+    ContentBlockVersion,
+    ContentImage,
+    ContentStatus,
+)
 from app.schemas.content import ContentBlockCreate, ContentBlockUpdate
 from app.services import storage
 
 
 async def get_published_by_key(session: AsyncSession, key: str) -> ContentBlock | None:
     result = await session.execute(
-        select(ContentBlock).where(ContentBlock.key == key, ContentBlock.status == ContentStatus.published)
+        select(ContentBlock)
+        .options(selectinload(ContentBlock.images), selectinload(ContentBlock.audits))
+        .where(ContentBlock.key == key, ContentBlock.status == ContentStatus.published)
     )
     return result.scalar_one_or_none()
 
 
 async def get_block_by_key(session: AsyncSession, key: str) -> ContentBlock | None:
-    result = await session.execute(select(ContentBlock).where(ContentBlock.key == key))
+    result = await session.execute(
+        select(ContentBlock)
+        .options(selectinload(ContentBlock.images), selectinload(ContentBlock.audits))
+        .where(ContentBlock.key == key)
+    )
     return result.scalar_one_or_none()
 
 
-async def upsert_block(session: AsyncSession, key: str, payload: ContentBlockUpdate | ContentBlockCreate) -> ContentBlock:
+async def upsert_block(
+    session: AsyncSession, key: str, payload: ContentBlockUpdate | ContentBlockCreate, actor_id: UUID | None = None
+) -> ContentBlock:
     block = await get_block_by_key(session, key)
     now = datetime.now(timezone.utc)
     data = payload.model_dump(exclude_unset=True)
@@ -48,7 +64,8 @@ async def upsert_block(session: AsyncSession, key: str, payload: ContentBlockUpd
             body_markdown=block.body_markdown,
             status=block.status,
         )
-        session.add(version_row)
+        audit = ContentAuditLog(content_block_id=block.id, action="created", version=block.version, user_id=actor_id)
+        session.add_all([version_row, audit])
         await session.commit()
         await session.refresh(block)
         return block
@@ -76,21 +93,23 @@ async def upsert_block(session: AsyncSession, key: str, payload: ContentBlockUpd
         body_markdown=block.body_markdown,
         status=block.status,
     )
-    session.add(version_row)
+    audit = ContentAuditLog(content_block_id=block.id, action="updated", version=block.version, user_id=actor_id)
+    session.add_all([version_row, audit])
     await session.commit()
     await session.refresh(block)
     return block
 
 
-async def add_image(session: AsyncSession, block: ContentBlock, file) -> ContentBlock:
+async def add_image(session: AsyncSession, block: ContentBlock, file, actor_id: UUID | None = None) -> ContentBlock:
     if not file.content_type or not file.content_type.startswith("image/"):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid file type")
     path, filename = storage.save_upload(file)
     next_sort = (max([img.sort_order for img in block.images], default=0) or 0) + 1
     image = ContentImage(content_block_id=block.id, url=path, alt_text=filename, sort_order=next_sort)
-    session.add(image)
+    audit = ContentAuditLog(content_block_id=block.id, action="image_upload", version=block.version, user_id=actor_id)
+    session.add_all([image, audit])
     await session.commit()
-    await session.refresh(block, attribute_names=["images"])
+    await session.refresh(block, attribute_names=["images", "audits"])
     return block
 
 

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,0 +1,44 @@
+import smtplib
+from email.message import EmailMessage
+from typing import Sequence
+
+from app.core.config import settings
+
+
+def _build_message(to_email: str, subject: str, text_body: str, html_body: str | None = None) -> EmailMessage:
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = settings.smtp_from_email or "no-reply@adrianaart.local"
+    msg["To"] = to_email
+    msg.set_content(text_body)
+    if html_body:
+        msg.add_alternative(html_body, subtype="html")
+    return msg
+
+
+async def send_email(to_email: str, subject: str, text_body: str, html_body: str | None = None) -> bool:
+    if not settings.smtp_enabled:
+        return False
+    msg = _build_message(to_email, subject, text_body, html_body)
+    try:
+        with smtplib.SMTP(settings.smtp_host, settings.smtp_port, timeout=10) as smtp:
+            if settings.smtp_use_tls:
+                smtp.starttls()
+            if settings.smtp_username and settings.smtp_password:
+                smtp.login(settings.smtp_username, settings.smtp_password)
+            smtp.send_message(msg)
+        return True
+    except Exception:
+        return False
+
+
+async def send_order_confirmation(to_email: str, order, items: Sequence | None = None) -> bool:
+    subject = f"Order confirmation {order.reference_code or order.id}"
+    lines = [f"Thank you for your order {order.reference_code or order.id}."]
+    if items:
+        lines.append("Items:")
+        for item in items:
+            lines.append(f"- {getattr(item, 'product_id', '')} x {item.quantity}")
+    lines.append(f"Total: {order.total_amount} {getattr(order, 'currency', 'USD')}")
+    text_body = "\n".join(lines)
+    return await send_email(to_email, subject, text_body)


### PR DESCRIPTION
- **Summary**
  - Add content audit logging, static page support, and SMTP-backed email service with order confirmations.
- **Changes**
  - Content models now include meta/sort ordering, images, audit log table, audit endpoints, static page route, and stricter markdown sanitization.
  - Added email settings and reusable email service plus order confirmation email trigger on order creation.
  - New migrations (0018/0019), updated schemas/routes/services, and expanded tests for content flows and order email stubs.
- **Testing**
  - `PYTHONPATH=backend DATABASE_URL=sqlite+aiosqlite:///:memory: .venv/bin/python -m pytest -q`
- **Risk & Impact**
  - Requires running migrations 0018 and 0019; email sending gated by `smtp_enabled` flag (default off) to avoid failures without SMTP.
- **Related TODO items**
  - [x] Content change audit log.
  - [x] Static page slugs for SEO (about/faq/shipping/returns/care).
  - [x] Email settings (SMTP).
  - [x] Generic email service (text + HTML).
  - [x] Order confirmation email.