### PR TITLE
feat: add password reset and email notifications

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -122,11 +122,11 @@ Below is a structured checklist you can turn into issues.
 - [x] Email settings (SMTP).
 - [x] Generic email service (text + HTML).
 - [x] Order confirmation email.
-- [ ] Password reset email + one-time token flow.
-- [ ] Logging/error handling around email sending.
-- [ ] Background task for sending emails.
-- [ ] Shipping update email (with tracking link).
-- [ ] Delivery confirmation email.
+- [x] Password reset email + one-time token flow.
+- [x] Logging/error handling around email sending.
+- [x] Background task for sending emails.
+- [x] Shipping update email (with tracking link).
+- [x] Delivery confirmation email.
 - [ ] Cart abandonment email template.
 - [ ] Product back-in-stock notification flow.
 - [ ] Admin alert on low stock thresholds.

--- a/backend/alembic/versions/0020_password_reset_tokens.py
+++ b/backend/alembic/versions/0020_password_reset_tokens.py
@@ -1,0 +1,35 @@
+"""password reset tokens
+
+Revision ID: 0020
+Revises: 0019
+Create Date: 2024-10-11
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0020"
+down_revision: str | None = "0019"
+branch_labels: str | Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "password_reset_tokens",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("user_id", sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("token", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_password_reset_token", "password_reset_tokens", ["token"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_password_reset_token", table_name="password_reset_tokens")
+    op.drop_table("password_reset_tokens")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,5 @@
 from app.db.base import Base  # noqa: F401
-from app.models.user import User  # noqa: F401
+from app.models.user import User, PasswordResetToken  # noqa: F401
 from app.models.catalog import (
     Category,
     Product,
@@ -22,6 +22,7 @@ from app.models.content import ContentBlock, ContentBlockVersion, ContentStatus,
 __all__ = [
     "Base",
     "User",
+    "PasswordResetToken",
     "Category",
     "Product",
     "ProductImage",

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, EmailStr
 
 from app.models.user import UserRole
 
@@ -36,3 +36,12 @@ class UserResponse(BaseModel):
 class AuthResponse(BaseModel):
     user: UserResponse
     tokens: TokenPair
+
+
+class PasswordResetRequest(BaseModel):
+    email: EmailStr
+
+
+class PasswordResetConfirm(BaseModel):
+    token: str
+    new_password: str

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,9 +1,11 @@
 from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
+from datetime import datetime, timedelta, timezone
+import secrets
 
 from app.core import security
-from app.models.user import User
+from app.models.user import User, PasswordResetToken
 from app.schemas.user import UserCreate
 
 
@@ -40,3 +42,37 @@ def issue_tokens_for_user(user: User) -> dict[str, str]:
         "access_token": security.create_access_token(str(user.id)),
         "refresh_token": security.create_refresh_token(str(user.id)),
     }
+
+
+async def create_reset_token(session: AsyncSession, email: str, expires_minutes: int = 60) -> PasswordResetToken:
+    user = await get_user_by_email(session, email)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    token = secrets.token_urlsafe(32)
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=expires_minutes)
+    reset = PasswordResetToken(user_id=user.id, token=token, expires_at=expires_at, used=False)
+    session.add(reset)
+    await session.commit()
+    await session.refresh(reset)
+    return reset
+
+
+async def confirm_reset_token(session: AsyncSession, token: str, new_password: str) -> User:
+    result = await session.execute(
+        select(PasswordResetToken).where(PasswordResetToken.token == token, PasswordResetToken.used.is_(False))
+    )
+    reset = result.scalar_one_or_none()
+    expires_at = reset.expires_at if reset else None
+    if expires_at and expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    if not reset or not expires_at or expires_at < datetime.now(timezone.utc):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired token")
+    user = await session.get(User, reset.user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    user.hashed_password = security.hash_password(new_password)
+    reset.used = True
+    session.add_all([user, reset])
+    await session.commit()
+    await session.refresh(user)
+    return user

--- a/backend/app/services/order.py
+++ b/backend/app/services/order.py
@@ -71,7 +71,12 @@ async def get_orders_for_user(session: AsyncSession, user_id: UUID) -> Sequence[
     result = await session.execute(
         select(Order)
         .where(Order.user_id == user_id)
-        .options(selectinload(Order.items), selectinload(Order.shipping_method), selectinload(Order.events))
+        .options(
+            selectinload(Order.items),
+            selectinload(Order.shipping_method),
+            selectinload(Order.events),
+            selectinload(Order.user),
+        )
         .order_by(Order.created_at.desc())
     )
     return result.scalars().all()
@@ -81,7 +86,12 @@ async def get_order(session: AsyncSession, user_id: UUID, order_id: UUID) -> Ord
     result = await session.execute(
         select(Order)
         .where(Order.user_id == user_id, Order.id == order_id)
-        .options(selectinload(Order.items), selectinload(Order.shipping_method), selectinload(Order.events))
+        .options(
+            selectinload(Order.items),
+            selectinload(Order.shipping_method),
+            selectinload(Order.events),
+            selectinload(Order.user),
+        )
     )
     return result.scalar_one_or_none()
 
@@ -89,7 +99,12 @@ async def get_order(session: AsyncSession, user_id: UUID, order_id: UUID) -> Ord
 async def list_orders(session: AsyncSession, status: OrderStatus | None = None, user_id: UUID | None = None) -> list[Order]:
     query = (
         select(Order)
-        .options(selectinload(Order.items), selectinload(Order.shipping_method), selectinload(Order.events))
+        .options(
+            selectinload(Order.items),
+            selectinload(Order.shipping_method),
+            selectinload(Order.events),
+            selectinload(Order.user),
+        )
         .order_by(Order.created_at.desc())
     )
     if status:
@@ -179,7 +194,12 @@ async def list_shipping_methods(session: AsyncSession) -> list[ShippingMethod]:
 async def get_order_by_id(session: AsyncSession, order_id: UUID) -> Order | None:
     result = await session.execute(
         select(Order)
-        .options(selectinload(Order.items), selectinload(Order.shipping_method), selectinload(Order.events))
+        .options(
+            selectinload(Order.items),
+            selectinload(Order.shipping_method),
+            selectinload(Order.events),
+            selectinload(Order.user),
+        )
         .where(Order.id == order_id)
     )
     return result.scalar_one_or_none()


### PR DESCRIPTION
- **Summary**
  - Implement password reset token flow with email delivery and add shipping/delivery notification emails.
- **Changes**
  - Added password reset token model/migration, auth endpoints for request/confirm, and tests.
  - Email service now logs failures, supports password reset, shipping update, and delivery confirmation helpers, with background sending for order confirmations and shipping status updates.
  - Orders API triggers shipping emails on status change and exposes a delivery email endpoint; order queries now load user relations for notifications.
- **Testing**
  - `PYTHONPATH=backend DATABASE_URL=sqlite+aiosqlite:///:memory: .venv/bin/python -m pytest -q`
- **Risk & Impact**
  - Requires running migration 0020; email sending still gated by `smtp_enabled`.
- **Related TODO items**
  - [x] Password reset email + one-time token flow.
  - [x] Logging/error handling around email sending.
  - [x] Background task for sending emails.
  - [x] Shipping update email (with tracking link).
  - [x] Delivery confirmation email.