### PR TITLE
feat: improve logging and rate limits

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -143,12 +143,12 @@ Below is a structured checklist you can turn into issues.
 - [x] Health/readiness endpoints.
 - [x] Pytest suite for services (auth, catalog, cart, checkout).
 - [x] Integration tests against temp Postgres.
-- [ ] mypy type-checking and fixes.
-- [ ] CI smoke test hitting health/readiness.
+- [x] mypy type-checking and fixes.
+- [x] CI smoke test hitting health/readiness.
 - [ ] DRF-style schema docs via OpenAPI tweaks.
-- [ ] API rate limit tests.
-- [ ] Structured logging format (JSON) toggle.
-- [ ] Request ID propagation to logs.
+- [x] API rate limit tests.
+- [x] Structured logging format (JSON) toggle.
+- [x] Request ID propagation to logs.
 - [ ] DB connection pool monitoring.
 - [ ] Cache layer placeholder (e.g., Redis) for rate limits.
 - [ ] Secure password reset tokens (expiry, blacklist).

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -35,11 +35,17 @@ class Settings(BaseSettings):
     smtp_from_email: str | None = None
     email_rate_limit_per_minute: int = 60
     email_rate_limit_per_recipient_per_minute: int = 10
+    auth_rate_limit_register: int = 10
+    auth_rate_limit_login: int = 20
+    auth_rate_limit_refresh: int = 60
+    auth_rate_limit_reset_request: int = 30
+    auth_rate_limit_reset_confirm: int = 60
 
     frontend_origin: str = "http://localhost:4200"
     content_preview_token: str = "preview-token"
     error_alert_email: str | None = None
     admin_alert_email: str | None = None
+    log_json: bool = False
 
 
 @lru_cache

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import logging
+from contextvars import ContextVar
+from typing import Any
+
+request_id_ctx_var: ContextVar[str | None] = ContextVar("request_id", default=None)
+
+
+class RequestIdFilter(logging.Filter):
+    """Attach request_id from contextvars to every log record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial
+        record.request_id = request_id_ctx_var.get() or "-"
+        return True
+
+
+class JsonFormatter(logging.Formatter):
+    """Minimal JSON formatter for structured logs."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - simple serialization
+        base: dict[str, Any] = {
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "request_id": getattr(record, "request_id", "-"),
+        }
+        for field in ("path", "method", "status_code", "duration_ms"):
+            value = getattr(record, field, None)
+            if value is not None:
+                base[field] = value
+        return json.dumps(base, ensure_ascii=False)
+
+
+def configure_logging(json_logs: bool = False) -> None:
+    """Configure root logger with request-id aware formatter."""
+    handler = logging.StreamHandler()
+    handler.addFilter(RequestIdFilter())
+    if json_logs:
+        handler.setFormatter(JsonFormatter())
+    else:
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(name)s [%(request_id)s] %(message)s")
+        )
+
+    logging.basicConfig(level=logging.INFO, handlers=[handler], force=True)

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from typing import Awaitable, Callable, DefaultDict, Deque, Hashable, Iterable
+
+from fastapi import HTTPException, Request, status
+
+WindowBucket = Deque[float]
+
+
+def _prune(bucket: WindowBucket, now: float, window_seconds: int) -> None:
+    while bucket and now - bucket[0] > window_seconds:
+        bucket.popleft()
+
+
+def _enforce_limit(bucket: WindowBucket, limit: int, window_seconds: int, now: float) -> None:
+    _prune(bucket, now, window_seconds)
+    if len(bucket) >= limit:
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Too many requests")
+    bucket.append(now)
+
+
+def limiter(
+    key: Hashable, limit: int, window_seconds: int
+) -> Callable[[Request], Awaitable[None]]:
+    """
+    Simple in-memory rate limiter shared per-process.
+
+    Args:
+        key: identifier for the bucket (e.g., "auth:login").
+        limit: max requests allowed in the window.
+        window_seconds: rolling window length in seconds.
+    """
+    buckets: DefaultDict[Hashable, WindowBucket] = defaultdict(deque)
+
+    async def dependency(_: Request) -> None:
+        now = time.time()
+        _enforce_limit(buckets[key], limit, window_seconds, now)
+
+    dependency.buckets = buckets  # type: ignore[attr-defined]
+    return dependency
+
+
+def per_identifier_limiter(
+    identifier_fn: Callable[[Request], Hashable], limit: int, window_seconds: int
+) -> Callable[[Request], Awaitable[None]]:
+    """
+    Rate limiter that uses a dynamic identifier (e.g., client IP or user id).
+
+    Args:
+        identifier_fn: function that maps the request to an identifier.
+        limit: max requests allowed in the window.
+        window_seconds: rolling window length in seconds.
+    """
+    buckets: DefaultDict[Hashable, WindowBucket] = defaultdict(deque)
+
+    async def dependency(request: Request) -> None:
+        ident = identifier_fn(request)
+        now = time.time()
+        _enforce_limit(buckets[ident], limit, window_seconds, now)
+
+    dependency.buckets = buckets  # type: ignore[attr-defined]
+    return dependency
+
+
+def reset_buckets(buckets: Iterable[DefaultDict[Hashable, WindowBucket]]) -> None:
+    """Helper for tests to clear limiter state."""
+    for bucket in buckets:
+        bucket.clear()

--- a/backend/app/middleware/__init__.py
+++ b/backend/app/middleware/__init__.py
@@ -1,0 +1,3 @@
+from app.middleware.request_log import RequestLoggingMiddleware
+
+__all__ = ["RequestLoggingMiddleware"]

--- a/backend/app/middleware/request_log.py
+++ b/backend/app/middleware/request_log.py
@@ -1,0 +1,36 @@
+import logging
+import time
+import uuid
+from typing import Awaitable, Callable
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.core.logging_config import request_id_ctx_var
+
+logger = logging.getLogger("app.request")
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        request_id = str(uuid.uuid4())
+        token = request_id_ctx_var.set(request_id)
+        start = time.time()
+        request.state.request_id = request_id
+        try:
+            response = await call_next(request)
+        finally:
+            request_id_ctx_var.reset(token)
+        duration = time.time() - start
+        response.headers["X-Request-ID"] = request_id
+        logger.info(
+            "request",
+            extra={
+                "request_id": request_id,
+                "path": request.url.path,
+                "method": request.method,
+                "status_code": response.status_code,
+                "duration_ms": int(duration * 1000),
+            },
+        )
+        return response

--- a/backend/app/services/content.py
+++ b/backend/app/services/content.py
@@ -101,9 +101,9 @@ async def upsert_block(
 
 
 async def add_image(session: AsyncSession, block: ContentBlock, file, actor_id: UUID | None = None) -> ContentBlock:
-    if not file.content_type or not file.content_type.startswith("image/"):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid file type")
-    path, filename = storage.save_upload(file)
+    path, filename = storage.save_upload(
+        file, allowed_content_types=("image/png", "image/jpeg", "image/webp", "image/gif"), max_bytes=5 * 1024 * 1024
+    )
     next_sort = (max([img.sort_order for img in block.images], default=0) or 0) + 1
     image = ContentImage(content_block_id=block.id, url=path, alt_text=filename, sort_order=next_sort)
     audit = ContentAuditLog(content_block_id=block.id, action="image_upload", version=block.version, user_id=actor_id)

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -10,3 +10,14 @@ def test_healthcheck() -> None:
     response = client.get("/api/v1/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+def test_readiness() -> None:
+    response = client.get("/api/v1/health/ready")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready"}
+
+
+def test_request_id_header() -> None:
+    response = client.get("/api/v1/health")
+    assert response.headers.get("X-Request-ID")

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,64 @@
+import asyncio
+from typing import Dict
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.api.v1 import auth as auth_api
+from app.db.base import Base
+from app.db.session import get_session
+from app.main import app
+
+
+@pytest.fixture
+def rate_limit_app() -> Dict[str, object]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def init_models() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(init_models())
+
+    async def override_get_session():
+        async with SessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    for dep in [
+        auth_api.login_rate_limit,
+        auth_api.register_rate_limit,
+        auth_api.refresh_rate_limit,
+        auth_api.reset_request_rate_limit,
+        auth_api.reset_confirm_rate_limit,
+    ]:
+        dep.buckets.clear()
+    client = TestClient(app)
+    yield {"client": client}
+    client.close()
+    app.dependency_overrides.clear()
+    for dep in [
+        auth_api.login_rate_limit,
+        auth_api.register_rate_limit,
+        auth_api.refresh_rate_limit,
+        auth_api.reset_request_rate_limit,
+        auth_api.reset_confirm_rate_limit,
+    ]:
+        dep.buckets.clear()
+
+
+def test_login_rate_limiter(rate_limit_app: Dict[str, object]) -> None:
+    client: TestClient = rate_limit_app["client"]  # type: ignore[assignment]
+    payload = {"email": "limited@example.com", "password": "pass12345", "name": "Limiter"}
+    res = client.post("/api/v1/auth/register", json=payload)
+    assert res.status_code == 201, res.text
+
+    limit = auth_api.settings.auth_rate_limit_login
+    for _ in range(limit):
+        ok = client.post("/api/v1/auth/login", json={"email": payload["email"], "password": payload["password"]})
+        assert ok.status_code == 200, ok.text
+
+    blocked = client.post("/api/v1/auth/login", json={"email": payload["email"], "password": payload["password"]})
+    assert blocked.status_code == 429

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+ignore_missing_imports = True
+exclude = venv|.venv|frontend|infra
+python_version = 3.12
+
+[mypy-sqlalchemy.*]
+ignore_missing_imports = True
+
+[mypy-jinja2.*]
+ignore_missing_imports = True


### PR DESCRIPTION
**Summary**
- add structured logging configuration with request IDs and optional JSON output
- enforce upload validation, rate limiter utilities, and tests to cover rate limit behavior and readiness

**Changes**
- introduce request logging middleware with request-id propagation and configurable JSON/text logging
- add in-memory rate limiter helpers and wire auth endpoints to per-identifier/global limits
- validate uploads via storage helper; add mypy config and refresh health/readiness coverage
- add rate limit test coverage and ensure readiness endpoint is exercised in CI smoke tests

**Testing**
- PYTHONPATH=backend DATABASE_URL=sqlite+aiosqlite:///:memory: .venv/bin/python -m pytest -q

**Risk & Impact**
- low; rate limits are in-memory per-process and configurable via settings

**Related TODO items**
- [x] mypy type-checking and fixes.
- [x] CI smoke test hitting health/readiness.
- [x] API rate limit tests.
- [x] Structured logging format (JSON) toggle.
- [x] Request ID propagation to logs.