### PR TITLE
fix: import common module in shared components

### DIFF
--- a/frontend/src/app/shared/skeleton.component.ts
+++ b/frontend/src/app/shared/skeleton.component.ts
@@ -1,8 +1,10 @@
 import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-skeleton',
   standalone: true,
+  imports: [CommonModule],
   template: `
     <div
       [ngClass]="[shape === 'circle' ? 'rounded-full' : 'rounded-lg', 'bg-slate-200/70 animate-pulse']"

--- a/frontend/src/app/shared/spinner.component.ts
+++ b/frontend/src/app/shared/spinner.component.ts
@@ -1,8 +1,10 @@
 import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-spinner',
   standalone: true,
+  imports: [CommonModule],
   template: `
     <div class="flex items-center justify-center gap-2" [ngClass]="inline ? 'inline-flex' : 'flex'">
       <span class="h-4 w-4 rounded-full border-2 border-slate-300 border-t-slate-900 animate-spin"></span>


### PR DESCRIPTION
**Summary**
- Fix Angular standalone spinner and skeleton components by adding CommonModule for NgClass/NgIf bindings.
- Refresh frontend package-lock with Node 20 to resolve npm install/ci lockfile mismatches.

**Changes**
- Import CommonModule into `SkeletonComponent` and `SpinnerComponent` to enable `ngClass`/`*ngIf`.
- Regenerated `frontend/package-lock.json` to align with `package.json` dependencies.

**Testing**
- `npm run build` (with Node 20 via nvm) – success.

**Risk & Impact**
- Low, template binding-only change to shared components; lockfile refresh only.

**Related TODO items**
- None (build fix).
