### PR TITLE
chore: add start scripts

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,36 @@
+@echo off
+setlocal
+
+set "ROOT=%~dp0"
+if "%ROOT:~-1%"=="\" set "ROOT=%ROOT:~0,-1%"
+set "BACKEND=%ROOT%\backend"
+set "FRONTEND=%ROOT%\frontend"
+set "VENV=%ROOT%\.venv"
+
+where python >nul 2>nul || (echo Python is required. && exit /b 1)
+where npm >nul 2>nul || (echo npm is required. && exit /b 1)
+
+if not exist "%VENV%\Scripts\python.exe" (
+  python -m venv "%VENV%"
+)
+call "%VENV%\Scripts\activate.bat"
+pip install -r "%BACKEND%\requirements.txt"
+
+if not exist "%FRONTEND%\node_modules" (
+  pushd "%FRONTEND%"
+  npm install
+  popd
+)
+
+if "%UVICORN_HOST%"=="" set "UVICORN_HOST=127.0.0.1"
+if "%UVICORN_PORT%"=="" set "UVICORN_PORT=8000"
+
+echo Starting backend on http://%UVICORN_HOST%:%UVICORN_PORT%
+start "backend" cmd /k "cd /d %BACKEND% && \"%VENV%\Scripts\python.exe\" -m uvicorn app.main:app --host %UVICORN_HOST% --port %UVICORN_PORT% --reload"
+
+echo Starting frontend dev server on http://localhost:4200
+pushd "%FRONTEND%"
+npm start
+popd
+
+endlocal

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple dev launcher for backend (FastAPI) and frontend (Angular)
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="${ROOT_DIR}/backend"
+FRONTEND_DIR="${ROOT_DIR}/frontend"
+VENV_DIR="${ROOT_DIR}/.venv"
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 is required"; exit 1; }
+command -v npm >/dev/null 2>&1 || { echo "npm is required"; exit 1; }
+
+# Python env + deps
+if [ ! -d "${VENV_DIR}" ]; then
+  python3 -m venv "${VENV_DIR}"
+fi
+# shellcheck disable=SC1091
+source "${VENV_DIR}/bin/activate"
+pip install -r "${BACKEND_DIR}/requirements.txt"
+
+# Node deps
+if [ ! -d "${FRONTEND_DIR}/node_modules" ]; then
+  (cd "${FRONTEND_DIR}" && npm install)
+fi
+
+UVICORN_HOST="${UVICORN_HOST:-127.0.0.1}"
+UVICORN_PORT="${UVICORN_PORT:-8000}"
+
+echo "Starting backend on http://${UVICORN_HOST}:${UVICORN_PORT}"
+(cd "${BACKEND_DIR}" && exec uvicorn app.main:app --host "${UVICORN_HOST}" --port "${UVICORN_PORT}" --reload) &
+BACKEND_PID=$!
+trap 'kill "${BACKEND_PID}" 2>/dev/null || true' EXIT
+
+echo "Starting frontend dev server on http://localhost:4200"
+(cd "${FRONTEND_DIR}" && exec npm start)


### PR DESCRIPTION
**Summary**
- Add cross-platform dev startup helpers for backend (FastAPI) and frontend (Angular).

**Changes**
- Added `start.sh` for Linux/macOS: sets up Python venv, installs backend deps, installs frontend deps if needed, and runs uvicorn + Angular dev server.
- Added `start.bat` for Windows with equivalent setup and launch steps.

**Testing**
- Not run (scripts are setup helpers).

**Risk & Impact**
- Low; new helper scripts only.

**Related TODO items**
- None.
