### PR TITLE
feat: add shop error state, breadcrumbs, and localized currency

### DIFF
--- a/frontend/src/app/shared/localized-currency.pipe.ts
+++ b/frontend/src/app/shared/localized-currency.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'localizedCurrency',
+  standalone: true
+})
+export class LocalizedCurrencyPipe implements PipeTransform {
+  transform(value: number, currency: string, locale?: string): string {
+    const loc = locale || (typeof navigator !== 'undefined' ? navigator.language : 'en-US');
+    return new Intl.NumberFormat(loc, { style: 'currency', currency }).format(value);
+  }
+}

--- a/frontend/src/app/shared/product-card.component.ts
+++ b/frontend/src/app/shared/product-card.component.ts
@@ -1,13 +1,14 @@
-import { CommonModule, CurrencyPipe, NgOptimizedImage } from '@angular/common';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { Product } from '../core/catalog.service';
 import { ButtonComponent } from './button.component';
+import { LocalizedCurrencyPipe } from './localized-currency.pipe';
 
 @Component({
   selector: 'app-product-card',
   standalone: true,
-  imports: [CommonModule, RouterLink, NgOptimizedImage, CurrencyPipe, ButtonComponent],
+  imports: [CommonModule, RouterLink, NgOptimizedImage, LocalizedCurrencyPipe, ButtonComponent],
   template: `
     <article class="group grid gap-3 rounded-2xl border border-slate-200 bg-white p-3 shadow-sm hover:-translate-y-1 hover:shadow-md transition">
       <a [routerLink]="['/products', product.slug]" class="block overflow-hidden rounded-xl bg-slate-50 relative">
@@ -32,7 +33,7 @@ import { ButtonComponent } from './button.component';
           </a>
           <span class="text-sm text-slate-500">{{ product.currency }}</span>
         </div>
-        <p class="text-lg font-semibold text-slate-900">{{ product.base_price | currency : product.currency }}</p>
+        <p class="text-lg font-semibold text-slate-900">{{ product.base_price | localizedCurrency : product.currency }}</p>
         <p *ngIf="product.short_description" class="text-sm text-slate-600 line-clamp-2">
           {{ product.short_description }}
         </p>


### PR DESCRIPTION
**Summary**
- Improve shop UX with error/retry state, price sliders, tag pills, query-param persistence, and breadcrumbs.
- Add localized currency formatting and breadcrumb/meta updates on product detail, plus recently-viewed carousel and image zoom overlay.
- Mark relevant storefront TODOs as completed.

**Changes**
- Shop page: breadcrumbs, price sliders alongside inputs, tag pills, retryable error state, query-param sync, and updated empty state actions.
- Product detail: localized currency pipe, breadcrumbs, meta tags (title/description/og), recently viewed carousel (localStorage), and click-to-zoom overlay for gallery images.
- Product cards use localized currency and show tag/featured badges; added shared `LocalizedCurrencyPipe`.
- TODO updated for completed tasks.

**Testing**
- `npm run build` (Node 20 via nvm) – success.

**Risk & Impact**
- Frontend-only; new query-param behavior for shop filters and localStorage use for recently viewed. Minimal risk; verify catalog API availability.

**Related TODO items**
- [x] Error state/retry for product lists.
- [x] Breadcrumbs for category/product pages.
- [x] Recently viewed carousel.
- [x] Localized currency display.
- [x] SEO meta tags per product/category.
