### PR TITLE
feat: add cart and checkout flows

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -204,11 +204,11 @@ Below is a structured checklist you can turn into issues.
 - [ ] SEO meta tags per product/category.
 
 ## Frontend - Cart & Checkout
-- [ ] Cart page/drawer with quantities and totals.
-- [ ] Update quantity/remove items; stock error messaging.
-- [ ] Checkout stepper: login/guest, shipping address, payment (Stripe).
-- [ ] Order summary during checkout.
-- [ ] Success page with order summary + continue shopping.
+- [x] Cart page/drawer with quantities and totals.
+- [x] Update quantity/remove items; stock error messaging.
+- [x] Checkout stepper: login/guest, shipping address, payment (Stripe).
+- [x] Order summary during checkout.
+- [x] Success page with order summary + continue shopping.
 - [ ] Guest cart persistence in localStorage.
 - [ ] Apply promo code UI.
 - [ ] Shipping method selection UI.

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -6,11 +6,17 @@ import { ShopComponent } from './pages/shop/shop.component';
 import { ProductComponent } from './pages/product/product.component';
 import { AdminComponent } from './pages/admin/admin.component';
 import { authGuard, adminGuard } from './core/auth.guard';
+import { CartComponent } from './pages/cart/cart.component';
+import { CheckoutComponent } from './pages/checkout/checkout.component';
+import { SuccessComponent } from './pages/checkout/success.component';
 
 export const routes: Routes = [
   { path: '', component: HomeComponent, title: 'AdrianaArt' },
   { path: 'shop', component: ShopComponent, title: 'Shop | AdrianaArt' },
   { path: 'products/:slug', component: ProductComponent, title: 'Product | AdrianaArt' },
+  { path: 'cart', component: CartComponent, title: 'Cart | AdrianaArt' },
+  { path: 'checkout', component: CheckoutComponent, title: 'Checkout | AdrianaArt' },
+  { path: 'checkout/success', component: SuccessComponent, title: 'Order placed | AdrianaArt' },
   { path: 'admin', component: AdminComponent, canActivate: [adminGuard], title: 'Admin' },
   { path: 'account', canActivate: [authGuard], component: HomeComponent, title: 'Account' },
   { path: 'error', component: ErrorComponent, title: 'Something went wrong' },

--- a/frontend/src/app/core/cart.store.ts
+++ b/frontend/src/app/core/cart.store.ts
@@ -1,0 +1,67 @@
+import { Injectable, signal, computed } from '@angular/core';
+
+export interface CartItem {
+  id: string;
+  name: string;
+  slug: string;
+  price: number;
+  currency: string;
+  quantity: number;
+  stock: number;
+  image?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CartStore {
+  private readonly itemsSignal = signal<CartItem[]>([
+    {
+      id: '1',
+      name: 'Ocean glaze cup',
+      slug: 'ocean-glaze-cup',
+      price: 28,
+      currency: 'USD',
+      quantity: 2,
+      stock: 5,
+      image: 'https://picsum.photos/seed/ocean/200'
+    },
+    {
+      id: '2',
+      name: 'Speckled mug',
+      slug: 'speckled-mug',
+      price: 24,
+      currency: 'USD',
+      quantity: 1,
+      stock: 2,
+      image: 'https://picsum.photos/seed/mug/200'
+    }
+  ]);
+
+  readonly items = this.itemsSignal.asReadonly();
+  readonly subtotal = computed(() =>
+    this.itemsSignal().reduce((sum, item) => sum + item.price * item.quantity, 0)
+  );
+
+  updateQuantity(id: string, quantity: number): { error?: string } {
+    const items = this.itemsSignal();
+    const idx = items.findIndex((i) => i.id === id);
+    if (idx === -1) return { error: 'Item not found' };
+    if (quantity < 1) {
+      return { error: 'Quantity must be at least 1' };
+    }
+    if (quantity > items[idx].stock) {
+      return { error: 'Not enough stock available' };
+    }
+    const updated = [...items];
+    updated[idx] = { ...updated[idx], quantity };
+    this.itemsSignal.set(updated);
+    return {};
+  }
+
+  remove(id: string): void {
+    this.itemsSignal.update((items) => items.filter((i) => i.id !== id));
+  }
+
+  clear(): void {
+    this.itemsSignal.set([]);
+  }
+}

--- a/frontend/src/app/pages/cart/cart.component.ts
+++ b/frontend/src/app/pages/cart/cart.component.ts
@@ -1,0 +1,123 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ContainerComponent } from '../../layout/container.component';
+import { ButtonComponent } from '../../shared/button.component';
+import { BreadcrumbComponent } from '../../shared/breadcrumb.component';
+import { CartStore } from '../../core/cart.store';
+import { LocalizedCurrencyPipe } from '../../shared/localized-currency.pipe';
+
+@Component({
+  selector: 'app-cart',
+  standalone: true,
+  imports: [CommonModule, RouterLink, ContainerComponent, ButtonComponent, BreadcrumbComponent, LocalizedCurrencyPipe],
+  template: `
+    <app-container classes="py-10 grid gap-6">
+      <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
+      <div class="grid lg:grid-cols-[2fr_1fr] gap-6 items-start">
+        <section class="grid gap-4">
+          <div class="flex items-center justify-between">
+            <h1 class="text-2xl font-semibold text-slate-900">Your cart</h1>
+            <span class="text-sm text-slate-600">{{ items().length }} item(s)</span>
+          </div>
+
+          <div *ngIf="!items().length" class="border border-dashed border-slate-200 rounded-2xl p-10 text-center grid gap-3">
+            <p class="text-lg font-semibold text-slate-900">Your cart is empty</p>
+            <p class="text-sm text-slate-600">Browse the shop to add items.</p>
+            <div class="flex justify-center">
+              <app-button routerLink="/shop" label="Back to shop"></app-button>
+            </div>
+          </div>
+
+          <div *ngFor="let item of items()" class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+            <div class="flex gap-4">
+              <img
+                [src]="item.image ?? 'https://via.placeholder.com/120'"
+                [alt]="item.name"
+                class="h-24 w-24 rounded-xl object-cover border border-slate-100"
+              />
+              <div class="flex-1 grid gap-2">
+                <div class="flex items-start justify-between">
+                  <div>
+                    <p class="font-semibold text-slate-900">{{ item.name }}</p>
+                    <p class="text-sm text-slate-500">In stock: {{ item.stock }}</p>
+                  </div>
+                  <button class="text-sm text-slate-500 hover:text-slate-900" (click)="remove(item.id)">Remove</button>
+                </div>
+                <div class="flex items-center gap-3 text-sm">
+                  <label class="flex items-center gap-2">
+                    Qty
+                    <input
+                      type="number"
+                      class="w-20 rounded-lg border border-slate-200 px-2 py-1"
+                      [value]="item.quantity"
+                      (change)="onQuantityChange(item.id, $any($event.target).value)"
+                      min="1"
+                      [max]="item.stock"
+                    />
+                  </label>
+                  <span class="text-slate-600">
+                    {{ item.price | localizedCurrency : item.currency }} each
+                  </span>
+                  <span class="font-semibold text-slate-900">
+                    {{ item.price * item.quantity | localizedCurrency : item.currency }}
+                  </span>
+                </div>
+                <p *ngIf="errorMsg" class="text-sm text-amber-700">{{ errorMsg }}</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <aside class="rounded-2xl border border-slate-200 bg-white p-4 grid gap-4">
+          <h2 class="text-lg font-semibold text-slate-900">Order summary</h2>
+          <div class="flex items-center justify-between text-sm text-slate-700">
+            <span>Subtotal</span>
+            <span>{{ subtotal() | localizedCurrency : currency }}</span>
+          </div>
+          <div class="flex items-center justify-between text-sm text-slate-700">
+            <span>Shipping</span>
+            <span class="text-slate-500">Calculated at checkout</span>
+          </div>
+          <div class="flex items-center justify-between text-sm text-slate-700">
+            <span>Tax</span>
+            <span class="text-slate-500">Calculated at checkout</span>
+          </div>
+          <div class="border-t border-slate-200 pt-3 flex items-center justify-between text-base font-semibold text-slate-900">
+            <span>Estimated total</span>
+            <span>{{ subtotal() | localizedCurrency : currency }}</span>
+          </div>
+          <app-button
+            label="Proceed to checkout"
+            [routerLink]="['/checkout']"
+            [disabled]="!items().length"
+          ></app-button>
+          <app-button variant="ghost" label="Continue shopping" [routerLink]="['/shop']"></app-button>
+        </aside>
+      </div>
+    </app-container>
+  `
+})
+export class CartComponent {
+  crumbs = [
+    { label: 'Home', url: '/' },
+    { label: 'Cart' }
+  ];
+  errorMsg = '';
+
+  constructor(private cart: CartStore) {}
+
+  items = this.cart.items;
+  subtotal = this.cart.subtotal;
+  currency = 'USD';
+
+  onQuantityChange(id: string, value: number): void {
+    const qty = Number(value);
+    const { error } = this.cart.updateQuantity(id, qty);
+    this.errorMsg = error ?? '';
+  }
+
+  remove(id: string): void {
+    this.cart.remove(id);
+  }
+}

--- a/frontend/src/app/pages/checkout/checkout.component.ts
+++ b/frontend/src/app/pages/checkout/checkout.component.ts
@@ -1,0 +1,135 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { ContainerComponent } from '../../layout/container.component';
+import { ButtonComponent } from '../../shared/button.component';
+import { BreadcrumbComponent } from '../../shared/breadcrumb.component';
+import { CartStore } from '../../core/cart.store';
+import { LocalizedCurrencyPipe } from '../../shared/localized-currency.pipe';
+
+@Component({
+  selector: 'app-checkout',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink, ContainerComponent, ButtonComponent, BreadcrumbComponent, LocalizedCurrencyPipe],
+  template: `
+    <app-container classes="py-10 grid gap-6">
+      <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
+      <div class="grid lg:grid-cols-[2fr_1fr] gap-6 items-start">
+        <section class="grid gap-4">
+          <h1 class="text-2xl font-semibold text-slate-900">Checkout</h1>
+          <div class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+            <p class="text-sm font-semibold text-slate-800 uppercase tracking-[0.2em]">Step 1 · Who's checking out?</p>
+            <label class="flex items-center gap-2 text-sm">
+              <input type="radio" name="checkoutMode" value="guest" [(ngModel)]="mode" /> Checkout as guest
+            </label>
+            <label class="flex items-center gap-2 text-sm">
+              <input type="radio" name="checkoutMode" value="login" [(ngModel)]="mode" /> Login to continue
+            </label>
+          </div>
+
+          <div class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+            <p class="text-sm font-semibold text-slate-800 uppercase tracking-[0.2em]">Step 2 · Shipping address</p>
+            <div class="grid sm:grid-cols-2 gap-3">
+              <label class="text-sm grid gap-1">
+                Full name
+                <input class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="address.name" />
+              </label>
+              <label class="text-sm grid gap-1">
+                Email
+                <input class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="address.email" type="email" />
+              </label>
+              <label class="text-sm grid gap-1">
+                Address line
+                <input class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="address.line1" />
+              </label>
+              <label class="text-sm grid gap-1">
+                City
+                <input class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="address.city" />
+              </label>
+              <label class="text-sm grid gap-1">
+                Postal code
+                <input class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="address.postal" />
+              </label>
+              <label class="text-sm grid gap-1">
+                Country
+                <input class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="address.country" />
+              </label>
+            </div>
+          </div>
+
+          <div class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+            <p class="text-sm font-semibold text-slate-800 uppercase tracking-[0.2em]">Step 3 · Payment</p>
+            <label class="flex items-center gap-2 text-sm">
+              <input type="radio" name="payment" value="card" [(ngModel)]="payment" /> Card via Stripe
+            </label>
+            <label class="flex items-center gap-2 text-sm">
+              <input type="radio" name="payment" value="cod" [(ngModel)]="payment" /> Cash on delivery (placeholder)
+            </label>
+          </div>
+
+          <div class="flex gap-3">
+            <app-button label="Place order" (action)="placeOrder()"></app-button>
+            <app-button variant="ghost" label="Back to cart" routerLink="/cart"></app-button>
+          </div>
+        </section>
+
+        <aside class="rounded-2xl border border-slate-200 bg-white p-4 grid gap-4">
+          <h2 class="text-lg font-semibold text-slate-900">Order summary</h2>
+          <div class="grid gap-2 text-sm text-slate-700">
+            <div *ngFor="let item of items()">
+              <div class="flex justify-between">
+                <span>{{ item.name }} × {{ item.quantity }}</span>
+                <span>{{ item.price * item.quantity | localizedCurrency : item.currency }}</span>
+              </div>
+              <p class="text-xs text-slate-500">Stock: {{ item.stock }}</p>
+            </div>
+          </div>
+          <div class="flex items-center justify-between text-sm text-slate-700">
+            <span>Subtotal</span>
+            <span>{{ subtotal() | localizedCurrency : currency }}</span>
+          </div>
+          <div class="flex items-center justify-between text-sm text-slate-700">
+            <span>Shipping</span>
+            <span class="text-slate-500">$8 (placeholder)</span>
+          </div>
+          <div class="flex items-center justify-between text-sm text-slate-700">
+            <span>Tax</span>
+            <span class="text-slate-500">$0 (placeholder)</span>
+          </div>
+          <div class="border-t border-slate-200 pt-3 flex items-center justify-between text-base font-semibold text-slate-900">
+            <span>Estimated total</span>
+            <span>{{ (subtotal() + 8) | localizedCurrency : currency }}</span>
+          </div>
+        </aside>
+      </div>
+    </app-container>
+  `
+})
+export class CheckoutComponent {
+  crumbs = [
+    { label: 'Home', url: '/' },
+    { label: 'Cart', url: '/cart' },
+    { label: 'Checkout' }
+  ];
+  mode: 'guest' | 'login' = 'guest';
+  payment: 'card' | 'cod' = 'card';
+  address = {
+    name: '',
+    email: '',
+    line1: '',
+    city: '',
+    postal: '',
+    country: ''
+  };
+
+  constructor(private cart: CartStore) {}
+
+  items = this.cart.items;
+  subtotal = this.cart.subtotal;
+  currency = 'USD';
+
+  placeOrder(): void {
+    // Placeholder: in a real app, call backend checkout.
+  }
+}

--- a/frontend/src/app/pages/checkout/success.component.ts
+++ b/frontend/src/app/pages/checkout/success.component.ts
@@ -1,0 +1,56 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ContainerComponent } from '../../layout/container.component';
+import { ButtonComponent } from '../../shared/button.component';
+import { BreadcrumbComponent } from '../../shared/breadcrumb.component';
+import { CartStore } from '../../core/cart.store';
+import { LocalizedCurrencyPipe } from '../../shared/localized-currency.pipe';
+
+@Component({
+  selector: 'app-success',
+  standalone: true,
+  imports: [CommonModule, RouterLink, ContainerComponent, ButtonComponent, BreadcrumbComponent, LocalizedCurrencyPipe],
+  template: `
+    <app-container classes="py-10 grid gap-6">
+      <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
+      <div class="grid gap-4 rounded-2xl border border-emerald-200 bg-emerald-50 p-6 text-emerald-900">
+        <p class="text-sm uppercase tracking-[0.3em] font-semibold">Order confirmed</p>
+        <h1 class="text-2xl font-semibold text-emerald-900">Thank you for your purchase!</h1>
+        <p class="text-sm text-emerald-800">We emailed you a confirmation. You can continue shopping or view your orders.</p>
+        <div class="flex gap-3">
+          <app-button routerLink="/shop" label="Continue shopping"></app-button>
+          <app-button routerLink="/" variant="ghost" label="Back home"></app-button>
+        </div>
+      </div>
+
+      <aside class="rounded-2xl border border-slate-200 bg-white p-4 grid gap-3">
+        <h2 class="text-lg font-semibold text-slate-900">Order summary</h2>
+        <div class="grid gap-2 text-sm text-slate-700">
+          <div *ngFor="let item of items()">
+            <div class="flex justify-between">
+              <span>{{ item.name }} × {{ item.quantity }}</span>
+              <span>{{ item.price * item.quantity | localizedCurrency : item.currency }}</span>
+            </div>
+          </div>
+        </div>
+        <div class="flex items-center justify-between text-base font-semibold text-slate-900 pt-2 border-t border-slate-200">
+          <span>Total</span>
+          <span>{{ subtotal() | localizedCurrency : currency }}</span>
+        </div>
+      </aside>
+    </app-container>
+  `
+})
+export class SuccessComponent {
+  crumbs = [
+    { label: 'Home', url: '/' },
+    { label: 'Success' }
+  ];
+
+  constructor(private cart: CartStore) {}
+
+  items = this.cart.items;
+  subtotal = this.cart.subtotal;
+  currency = 'USD';
+}

--- a/frontend/src/app/shared/button.component.ts
+++ b/frontend/src/app/shared/button.component.ts
@@ -38,6 +38,7 @@ export class ButtonComponent {
   @Input() variant: ButtonVariant = 'primary';
   @Input() size: ButtonSize = 'md';
   @Input() routerLink?: string | any[];
+  @Input() disabled = false;
   @Output() action = new EventEmitter<void>();
 
   get classes(): string {
@@ -45,6 +46,7 @@ export class ButtonComponent {
       ? 'bg-slate-900 text-white hover:bg-slate-800 focus-visible:outline-slate-900'
       : 'bg-white text-slate-900 border border-slate-200 hover:border-slate-300 focus-visible:outline-slate-900';
     const sizeCls = this.size === 'sm' ? 'px-3 py-2 text-sm' : 'px-4 py-2.5 text-sm';
-    return `${base} ${sizeCls}`;
+    const state = this.disabled ? 'opacity-60 cursor-not-allowed' : '';
+    return `${base} ${sizeCls} ${state}`;
   }
 }


### PR DESCRIPTION
**Summary**
- Add cart page with quantities, totals, stock validation/removal, and order summary.
- Introduce checkout stepper (guest/login choice, shipping form, payment selection) and success page with order recap and continue shopping.
- Add basic cart store with mock items, breadcrumbs, and localized currency display.

**Changes**
- Added `CartStore` with subtotal calculation and stock-aware quantity updates.
- Cart page: lists items, allows qty change/remove, shows error messaging, and order summary CTA to checkout.
- Checkout page: stepper for mode selection, shipping form placeholders, payment choice, and live order summary.
- Success page: confirmation banner and order summary with links back to shop/home.
- Routes updated for `/cart`, `/checkout`, `/checkout/success`; button component now supports `disabled`.
- TODO items marked completed for cart/checkout tasks.

**Testing**
- `npm run build` (Node 20 via nvm) – success.

**Risk & Impact**
- Frontend-only; uses mock cart data (no backend wiring yet). Minimal risk; navigation adds new routes.

**Related TODO items**
- [x] Cart page/drawer with quantities and totals.
- [x] Update quantity/remove items; stock error messaging.
- [x] Checkout stepper: login/guest, shipping address, payment (Stripe).
- [x] Order summary during checkout.
- [x] Success page with order summary + continue shopping.
