### PR TITLE
fix: resolve admin maintenance and category reorder build errors

### DIFF
--- a/backend/app/api/v1/admin_dashboard.py
+++ b/backend/app/api/v1/admin_dashboard.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.dependencies import require_admin
 from app.db.session import get_session
 from app.models.catalog import Product, ProductAuditLog, Category

--- a/frontend/src/app/core/admin.service.ts
+++ b/frontend/src/app/core/admin.service.ts
@@ -203,9 +203,10 @@ export class AdminService {
   }
 
   reorderProductImage(slug: string, imageId: string, sortOrder: number): Observable<AdminProductDetail> {
-    return this.api.patch<AdminProductDetail>(`/catalog/products/${slug}/images/${imageId}/sort`, null, {
-      sort_order: sortOrder
-    } as any);
+    return this.api.patch<AdminProductDetail>(
+      `/catalog/products/${slug}/images/${imageId}/sort?sort_order=${sortOrder}`,
+      {}
+    );
   }
 
   updateUserRole(userId: string, role: string): Observable<AdminUser> {

--- a/frontend/src/app/pages/admin/admin.component.ts
+++ b/frontend/src/app/pages/admin/admin.component.ts
@@ -481,8 +481,19 @@ export class AdminComponent implements OnInit {
         this.contentAudit = logs.content;
       }
     });
-    this.admin.getCategories().subscribe({ next: (cats) => (this.categories = cats) });
-    this.admin.getMaintenance().subscribe({ next: (m) => this.maintenanceEnabled.set(m.enabled) });
+    this.admin.getCategories().subscribe({
+      next: (cats) => {
+        this.categories = cats
+          .map((c) => ({ ...c, sort_order: c.sort_order ?? 0 }))
+          .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
+      }
+    });
+    this.admin.getMaintenance().subscribe({
+      next: (m) => {
+        this.maintenanceEnabled.set(m.enabled);
+        this.maintenanceEnabledValue = m.enabled;
+      }
+    });
     this.loading.set(false);
   }
 
@@ -683,18 +694,20 @@ export class AdminComponent implements OnInit {
   }
 
   moveCategory(cat: AdminCategory, delta: number): void {
-    const sorted = [...this.categories].sort((a, b) => a.sort_order - b.sort_order);
+    const sorted = [...this.categories].sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
     const index = sorted.findIndex((c) => c.slug === cat.slug);
     const swapIndex = index + delta;
     if (index < 0 || swapIndex < 0 || swapIndex >= sorted.length) return;
-    const tmp = sorted[index].sort_order;
-    sorted[index].sort_order = sorted[swapIndex].sort_order;
+    const tmp = sorted[index].sort_order ?? 0;
+    sorted[index].sort_order = sorted[swapIndex].sort_order ?? 0;
     sorted[swapIndex].sort_order = tmp;
     this.admin
-      .reorderCategories(sorted.map((c) => ({ slug: c.slug, sort_order: c.sort_order })))
+      .reorderCategories(sorted.map((c) => ({ slug: c.slug, sort_order: c.sort_order ?? 0 })))
       .subscribe({
         next: (cats) => {
-          this.categories = cats.sort((a, b) => a.sort_order - b.sort_order);
+          this.categories = cats
+            .map((c) => ({ ...c, sort_order: c.sort_order ?? 0 }))
+            .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
           this.toast.success('Category order saved');
         },
         error: () => this.toast.error('Failed to reorder categories')
@@ -714,7 +727,7 @@ export class AdminComponent implements OnInit {
       this.draggingSlug = null;
       return;
     }
-    const sorted = [...this.categories].sort((a, b) => a.sort_order - b.sort_order);
+    const sorted = [...this.categories].sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
     const fromIdx = sorted.findIndex((c) => c.slug === this.draggingSlug);
     const toIdx = sorted.findIndex((c) => c.slug === targetSlug);
     if (fromIdx === -1 || toIdx === -1) {
@@ -725,10 +738,12 @@ export class AdminComponent implements OnInit {
     sorted.splice(toIdx, 0, moved);
     sorted.forEach((c, idx) => (c.sort_order = idx));
     this.admin
-      .reorderCategories(sorted.map((c) => ({ slug: c.slug, sort_order: c.sort_order })))
+      .reorderCategories(sorted.map((c) => ({ slug: c.slug, sort_order: c.sort_order ?? 0 })))
       .subscribe({
         next: (cats) => {
-          this.categories = cats.sort((a, b) => a.sort_order - b.sort_order);
+          this.categories = cats
+            .map((c) => ({ ...c, sort_order: c.sort_order ?? 0 }))
+            .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
           this.toast.success('Category order saved');
         },
         error: () => this.toast.error('Failed to reorder categories'),


### PR DESCRIPTION
**Summary**
- Fix backend lint error by importing settings in admin_dashboard maintenance endpoints.
- Fix frontend build errors: correct product image reorder API call signature, guard against undefined category sort_order, and make drag/drop reorder payloads typed.

**Changes**
- `admin_dashboard.py`: import `settings` for maintenance get/set.
- `admin.service.ts`: use query param for image reorder PATCH; add reorder/maintenance helpers.
- `admin.component.ts`: normalize category sort_order, drag-and-drop reorder safely with defaults, bind maintenance toggle correctly.

**Testing**
- Backend: `cd backend && PYTHONPATH=. ../.venv/bin/pytest -q` (pass).
- Frontend: `cd frontend && ... && ./node_modules/.bin/ng test --watch=false --browsers=ChromeHeadless` (pass).

**Risk & Impact**
- Minimal; fixes lint/build errors only.

**Related TODO items**
- None (bugfix).
