### PR TITLE
feat: add google oauth frontend flows

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -337,11 +337,11 @@ Below is a structured checklist you can turn into issues.
 - [x] `/auth/google/link` for logged-in users to link Google (password confirmation).
 - [x] `/auth/google/unlink` to disconnect Google profile (must retain password).
 - [x] Validation to prevent linking a Google account already linked elsewhere.
-- [ ] Frontend login/register “Continue with Google” flow and callback handling.
-- [ ] Account settings “Connected accounts” section with link/unlink actions.
+- [x] Frontend login/register “Continue with Google” flow and callback handling.
+- [x] Account settings “Connected accounts” section with link/unlink actions.
 - [x] Log security events for linking/unlinking and first-time Google logins.
 - [x] Unit tests for Google OAuth flows (happy path, link existing, conflicting emails, unlink).
-- [ ] README docs for Google OAuth setup/testing (console steps, redirect URLs).
+- [x] README docs for Google OAuth setup/testing (console steps, redirect URLs).
 
 ## Admin Dashboard – CMS & UX Enhancements
 - [ ] Admin UI for editing homepage hero per language (headline, subtitle, CTA, hero image).

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,9 +21,11 @@ Key env vars:
 - `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `GOOGLE_ALLOWED_DOMAINS` (optional list) for Google OAuth
 
 ### Google OAuth quick notes
-- Configure a Google OAuth client (Web) with authorized redirect URI matching `GOOGLE_REDIRECT_URI`.
-- Set env vars above; allowed domains is optional for restricting enterprise domains.
-- Flows: `/auth/google/start` for login, `/auth/google/callback` to exchange code; `/auth/google/link` and `/auth/google/unlink` for authenticated users (link requires password confirmation).
+- Configure a Google OAuth client (Web) with authorized redirect URI matching `GOOGLE_REDIRECT_URI` (e.g., `http://localhost:4200/auth/google/callback` in dev).
+- Set env vars above; `GOOGLE_ALLOWED_DOMAINS` is optional for restricting enterprise domains.
+- Frontend calls `/auth/google/start` and then posts the returned `code`/`state` to `/auth/google/callback` to exchange for tokens.
+- Authenticated users can link/unlink via `/auth/google/link/start` → `/auth/google/link` (requires password) and `/auth/google/unlink`.
+- Update the frontend `.env`/config to point `GOOGLE_REDIRECT_URI` at the Angular callback route when testing locally.
 
 ## Database and migrations
 

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -43,14 +43,15 @@ export class AppComponent {
   ) {
     const savedLang = typeof localStorage !== 'undefined' ? localStorage.getItem('lang') : null;
     const userLang = this.auth.user()?.preferred_language;
-    this.language = savedLang || userLang || (translate.getBrowserLang() === 'ro' ? 'ro' : 'en');
+    const browserLang = this.translate.getBrowserLang() ?? 'en';
+    this.language = userLang || savedLang || (browserLang === 'ro' ? 'ro' : 'en');
     this.translate.use(this.language);
   }
 
   onThemeChange(pref: ThemePreference): void {
     this.theme.setPreference(pref);
     const mode = this.theme.mode()().toUpperCase();
-    this.toast.success('Theme switched', `Theme is now ${mode}`);
+    this.toast.success(this.translate.instant('theme.switched'), this.translate.instant('theme.now', { mode }));
   }
 
   onLanguageChange(lang: string): void {
@@ -60,7 +61,13 @@ export class AppComponent {
       localStorage.setItem('lang', lang);
     }
     if (this.auth.isAuthenticated()) {
-      this.auth.updatePreferredLanguage(lang).subscribe();
+      this.auth.updatePreferredLanguage(lang).subscribe({
+        error: () =>
+          this.toast.error(
+            this.translate.instant('auth.languageNotSaved'),
+            this.translate.instant('auth.languageNotSavedDetail')
+          )
+      });
     }
   }
 }

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -11,6 +11,7 @@ import { CheckoutComponent } from './pages/checkout/checkout.component';
 import { SuccessComponent } from './pages/checkout/success.component';
 import { LoginComponent } from './pages/auth/login.component';
 import { RegisterComponent } from './pages/auth/register.component';
+import { GoogleCallbackComponent } from './pages/auth/google-callback.component';
 import { PasswordResetRequestComponent } from './pages/auth/password-reset-request.component';
 import { PasswordResetComponent } from './pages/auth/password-reset.component';
 import { AccountComponent } from './pages/account/account.component';
@@ -26,6 +27,7 @@ export const routes: Routes = [
   { path: 'checkout/success', component: SuccessComponent, title: 'Order placed | AdrianaArt' },
   { path: 'login', component: LoginComponent, title: 'Login | AdrianaArt' },
   { path: 'register', component: RegisterComponent, title: 'Register | AdrianaArt' },
+  { path: 'auth/google/callback', component: GoogleCallbackComponent, title: 'Google sign-in | AdrianaArt' },
   { path: 'password-reset', component: PasswordResetRequestComponent, title: 'Password reset | AdrianaArt' },
   { path: 'password-reset/confirm', component: PasswordResetComponent, title: 'Set new password | AdrianaArt' },
   { path: 'account', canActivate: [authGuard], component: AccountComponent, title: 'Account | AdrianaArt' },

--- a/frontend/src/app/pages/auth/google-callback.component.ts
+++ b/frontend/src/app/pages/auth/google-callback.component.ts
@@ -1,0 +1,96 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, signal } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { AuthService } from '../../core/auth.service';
+import { ToastService } from '../../core/toast.service';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-google-callback',
+  standalone: true,
+  imports: [CommonModule, TranslateModule],
+  template: `
+    <div class="min-h-screen flex items-center justify-center bg-slate-50 px-4">
+      <div class="bg-white border border-slate-200 rounded-xl shadow-sm p-6 w-full max-w-md grid gap-3 text-center">
+        <p class="text-lg font-semibold text-slate-900">{{ 'auth.googleFinishing' | translate }}</p>
+        <p class="text-sm text-slate-600" *ngIf="message()">{{ message() }}</p>
+        <p class="text-sm text-rose-700" *ngIf="error()">{{ error() }}</p>
+      </div>
+    </div>
+  `
+})
+export class GoogleCallbackComponent implements OnInit {
+  message = signal<string | null>(null);
+  error = signal<string | null>(null);
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private auth: AuthService,
+    private toast: ToastService,
+    private translate: TranslateService
+  ) {}
+
+  ngOnInit(): void {
+    const code = this.route.snapshot.queryParamMap.get('code');
+    const state = this.route.snapshot.queryParamMap.get('state');
+    const flow = (localStorage.getItem('google_flow') as 'login' | 'link' | null) || 'login';
+    if (!code || !state) {
+      this.error.set(this.translate.instant('auth.googleMissingCode'));
+      this.toast.error(this.translate.instant('auth.googleMissingCode'));
+      this.router.navigateByUrl('/login');
+      return;
+    }
+
+    if (flow === 'link') {
+      const password = sessionStorage.getItem('google_link_password');
+      if (!password) {
+        this.error.set(this.translate.instant('auth.googleLinkPasswordMissing'));
+        this.toast.error(this.translate.instant('auth.googleLinkPasswordMissing'));
+        this.router.navigateByUrl('/account');
+        return;
+      }
+      this.handleLink(code, state, password);
+    } else {
+      this.handleLogin(code, state);
+    }
+  }
+
+  private handleLogin(code: string, state: string): void {
+    this.message.set(this.translate.instant('auth.googleSigningIn'));
+    this.auth.completeGoogleLogin(code, state).subscribe({
+      next: (res) => {
+        localStorage.removeItem('google_flow');
+        this.toast.success(this.translate.instant('auth.googleLoginSuccess'), res.user.email);
+        this.router.navigateByUrl('/account');
+      },
+      error: (err) => {
+        localStorage.removeItem('google_flow');
+        const message = err?.error?.detail || this.translate.instant('auth.googleError');
+        this.error.set(message);
+        this.toast.error(message);
+        this.router.navigateByUrl('/login');
+      }
+    });
+  }
+
+  private handleLink(code: string, state: string, password: string): void {
+    this.message.set(this.translate.instant('auth.googleLinking'));
+    this.auth.completeGoogleLink(code, state, password).subscribe({
+      next: (user) => {
+        localStorage.removeItem('google_flow');
+        sessionStorage.removeItem('google_link_password');
+        this.toast.success(this.translate.instant('auth.googleLinkSuccess'), user.email);
+        this.router.navigateByUrl('/account');
+      },
+      error: (err) => {
+        localStorage.removeItem('google_flow');
+        sessionStorage.removeItem('google_link_password');
+        const message = err?.error?.detail || this.translate.instant('auth.googleError');
+        this.error.set(message);
+        this.toast.error(message);
+        this.router.navigateByUrl('/account');
+      }
+    });
+  }
+}

--- a/frontend/src/app/pages/auth/login.component.ts
+++ b/frontend/src/app/pages/auth/login.component.ts
@@ -44,6 +44,10 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
           <a routerLink="/register" class="text-slate-600 hover:text-slate-900">{{ 'auth.createAccount' | translate }}</a>
         </div>
         <app-button [label]="'auth.login' | translate" type="submit"></app-button>
+        <div class="border-t border-slate-200 pt-4 grid gap-2">
+          <p class="text-sm text-slate-600 text-center">{{ 'auth.orContinue' | translate }}</p>
+          <app-button variant="ghost" [label]="'auth.googleContinue' | translate" (action)="startGoogle()"></app-button>
+        </div>
       </form>
     </app-container>
   `
@@ -58,6 +62,19 @@ export class LoginComponent {
   loading = false;
 
   constructor(private toast: ToastService, private auth: AuthService, private router: Router, private translate: TranslateService) {}
+
+  startGoogle(): void {
+    localStorage.setItem('google_flow', 'login');
+    this.auth.startGoogleLogin().subscribe({
+      next: (url) => {
+        window.location.href = url;
+      },
+      error: (err) => {
+        const message = err?.error?.detail || this.translate.instant('auth.googleError');
+        this.toast.error(message);
+      }
+    });
+  }
 
   onSubmit(form: NgForm): void {
     if (!form.valid) return;

--- a/frontend/src/app/pages/auth/register.component.ts
+++ b/frontend/src/app/pages/auth/register.component.ts
@@ -49,6 +49,10 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
         </label>
         <p *ngIf="error" class="text-sm text-amber-700">{{ error }}</p>
         <app-button [label]="'auth.register' | translate" type="submit"></app-button>
+        <div class="border-t border-slate-200 pt-4 grid gap-2">
+          <p class="text-sm text-slate-600 text-center">{{ 'auth.orContinue' | translate }}</p>
+          <app-button variant="ghost" [label]="'auth.googleContinue' | translate" (action)="startGoogle()"></app-button>
+        </div>
         <p class="text-sm text-slate-600">
           {{ 'auth.haveAccount' | translate }}
           <a routerLink="/login" class="text-indigo-600 font-medium">{{ 'auth.login' | translate }}</a>
@@ -75,6 +79,17 @@ export class RegisterComponent {
     private router: Router,
     private translate: TranslateService
   ) {}
+
+  startGoogle(): void {
+    localStorage.setItem('google_flow', 'login');
+    this.auth.startGoogleLogin().subscribe({
+      next: (url) => (window.location.href = url),
+      error: (err) => {
+        const message = err?.error?.detail || this.translate.instant('auth.googleError');
+        this.toast.error(message);
+      }
+    });
+  }
 
   onSubmit(form: NgForm): void {
     if (!form.valid) {

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -168,7 +168,23 @@
     "successReset": "Password updated",
     "errorLogin": "Unable to login. Please try again.",
     "errorRegister": "Unable to register. Please try again.",
-    "errorReset": "Unable to reset password. Please try again."
+    "errorReset": "Unable to reset password. Please try again.",
+    "orContinue": "Or continue with",
+    "googleContinue": "Continue with Google",
+    "googleError": "Google sign-in failed. Please try again.",
+    "googleFinishing": "Finishing Google sign-in...",
+    "googleSigningIn": "Signing you in with Google...",
+    "googleLoginSuccess": "Signed in with Google",
+    "googleLinking": "Linking your Google account...",
+    "googleLinkSuccess": "Google account linked",
+    "googleMissingCode": "Missing Google authorization code.",
+    "googleLinkPasswordMissing": "Password required to link Google account.",
+    "languageNotSaved": "Language not saved",
+    "languageNotSavedDetail": "Could not update your preferred language. Please try again."
+  },
+  "theme": {
+    "switched": "Theme updated",
+    "now": "Theme is now {{mode}}"
   },
   "validation": {
     "required": "This field is required.",

--- a/frontend/src/assets/i18n/ro.json
+++ b/frontend/src/assets/i18n/ro.json
@@ -168,7 +168,23 @@
     "successReset": "Parolă actualizată",
     "errorLogin": "Autentificare eșuată. Încearcă din nou.",
     "errorRegister": "Nu am putut crea contul. Încearcă din nou.",
-    "errorReset": "Nu am putut reseta parola. Încearcă din nou."
+    "errorReset": "Nu am putut reseta parola. Încearcă din nou.",
+    "orContinue": "Sau continuă cu",
+    "googleContinue": "Continuă cu Google",
+    "googleError": "Autentificarea cu Google a eșuat. Încearcă din nou.",
+    "googleFinishing": "Finalizăm autentificarea cu Google...",
+    "googleSigningIn": "Te conectăm cu Google...",
+    "googleLoginSuccess": "Conectat cu Google",
+    "googleLinking": "Asociem contul Google...",
+    "googleLinkSuccess": "Contul Google a fost asociat",
+    "googleMissingCode": "Lipsește codul de autorizare Google.",
+    "googleLinkPasswordMissing": "Este necesară parola pentru a asocia contul Google.",
+    "languageNotSaved": "Limbajul nu a fost salvat",
+    "languageNotSavedDetail": "Nu am putut actualiza limba preferată. Încearcă din nou."
+  },
+  "theme": {
+    "switched": "Tema a fost schimbată",
+    "now": "Tema este acum {{mode}}"
   },
   "validation": {
     "required": "Acest câmp este obligatoriu.",


### PR DESCRIPTION
**Summary**
- Add Google sign-in/link UI across login/register, callback handling, and account settings.
- Wire Angular app to backend Google OAuth endpoints with new service helpers and translations.
- Document Google OAuth setup/redirect expectations in backend README.

**Changes**
- Added Google callback route/component and buttons on login/register that launch `/auth/google/start` and finish token exchange client-side.
- Implemented connected-accounts section in account page with link/unlink flows (password-confirmed) and status display.
- Updated auth service for Google start/callback/link/unlink, translated strings, and README notes for configuring redirect URIs.

**Testing**
- `PYTHONPATH=$PYTHONPATH:$(pwd)/backend pytest backend/tests/test_google_oauth.py`
- `npm run build`
- `CHROME_BIN=$(which chromium-browser || which chromium || which google-chrome) npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox`

**Risk & Impact**
- Requires valid Google OAuth env vars (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`) for the new flows to work end-to-end.
- Link/unlink still asks for password confirmation; missing password will block linking.

**Related TODO items**
- [x] Frontend login/register “Continue with Google” flow and callback handling.
- [x] Account settings “Connected accounts” section with link/unlink actions.
- [x] README docs for Google OAuth setup/testing (console steps, redirect URLs).