### PR TITLE
feat: add admin hero, collections, and home order

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -344,9 +344,9 @@ Below is a structured checklist you can turn into issues.
 - [x] README docs for Google OAuth setup/testing (console steps, redirect URLs).
 
 ## Admin Dashboard – CMS & UX Enhancements
-- [ ] Admin UI for editing homepage hero per language (headline, subtitle, CTA, hero image).
-- [ ] Admin UI for managing Collections (named groups of products to feature).
-- [ ] Drag-and-drop ordering for homepage sections (hero, collections, bestsellers, new arrivals).
+- [x] Admin UI for editing homepage hero per language (headline, subtitle, CTA, hero image).
+- [x] Admin UI for managing Collections (named groups of products to feature).
+- [x] Drag-and-drop ordering for homepage sections (hero, collections, bestsellers, new arrivals).
 - [ ] Admin UI for global assets (logo, favicon, social preview image).
 - [ ] SEO settings in admin to set meta title/description per page per language.
 - [ ] WYSIWYG/markdown editor for About/FAQ/Shipping content with RO/EN tabs.

--- a/frontend/src/app/core/admin.service.ts
+++ b/frontend/src/app/core/admin.service.ts
@@ -100,6 +100,25 @@ export interface LowStockItem {
   slug: string;
 }
 
+export interface FeaturedCollection {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string | null;
+  created_at: string;
+  product_ids?: string[];
+}
+
+export interface ContentBlock {
+  key: string;
+  title: string;
+  body_markdown: string;
+  status: string;
+  meta?: Record<string, any> | null;
+  lang?: string | null;
+  sort_order?: number;
+}
+
 @Injectable({ providedIn: 'root' })
 export class AdminService {
   constructor(private api: ApiService) {}
@@ -219,5 +238,28 @@ export class AdminService {
 
   setMaintenance(enabled: boolean): Observable<{ enabled: boolean }> {
     return this.api.post<{ enabled: boolean }>('/admin/dashboard/maintenance', { enabled });
+  }
+
+  // Featured collections
+  listFeaturedCollections(): Observable<FeaturedCollection[]> {
+    return this.api.get<FeaturedCollection[]>('/catalog/collections/featured');
+  }
+
+  createFeaturedCollection(payload: Partial<FeaturedCollection> & { product_ids?: string[] }): Observable<FeaturedCollection> {
+    return this.api.post<FeaturedCollection>('/catalog/collections/featured', payload);
+  }
+
+  updateFeaturedCollection(slug: string, payload: Partial<FeaturedCollection> & { product_ids?: string[] }): Observable<FeaturedCollection> {
+    return this.api.patch<FeaturedCollection>(`/catalog/collections/featured/${slug}`, payload);
+  }
+
+  // Content blocks (admin)
+  getContent(key: string, lang?: string): Observable<ContentBlock> {
+    const suffix = lang ? `?lang=${lang}` : '';
+    return this.api.get<ContentBlock>(`/content/admin/${key}${suffix}`);
+  }
+
+  createContent(key: string, payload: Partial<ContentBlock>): Observable<ContentBlock> {
+    return this.api.post<ContentBlock>(`/content/admin/${key}`, payload);
   }
 }


### PR DESCRIPTION
**Summary**
- Add admin tooling to edit the homepage hero per language (headline, subtitle, CTA, image) using content blocks.
- Enable featured collections management (create/update with product assignment) in admin.
- Provide drag-and-drop ordering for homepage sections and persist layout order in content.

**Changes**
- Extended AdminService with content fetch/create helpers and featured collection CRUD.
- Added hero form with language switch (EN/RO), CTA/meta fields, and save/create fallback.
- Added sections order UI (hero/collections/bestsellers/new arrivals) with drag/drop persistence.
- Added featured collections form/list with product multi-select and edit/save flow.
- Updated TODO.md to reflect completed admin CMS tasks.

**Testing**
- `npm run build`
- `CHROME_BIN=$(which chromium-browser || which chromium || which google-chrome) npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox`

**Risk & Impact**
- Relies on existing content/featured collection endpoints; ensure `home.hero` and `home.sections` content keys are permitted via content API.

**Related TODO items**
- [x] Admin UI for editing homepage hero per language (headline, subtitle, CTA, hero image).
- [x] Admin UI for managing Collections (named groups of products to feature).
- [x] Drag-and-drop ordering for homepage sections (hero, collections, bestsellers, new arrivals).