### PR TITLE
feat: add admin preview, seo, and stock tools

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -350,10 +350,10 @@ Below is a structured checklist you can turn into issues.
 - [x] Admin UI for global assets (logo, favicon, social preview image).
 - [x] SEO settings in admin to set meta title/description per page per language.
 - [x] WYSIWYG/markdown editor for About/FAQ/Shipping content with RO/EN tabs.
-- [ ] Live preview mode in admin for page changes before publishing.
-- [ ] Version metadata (“last updated by/at”) for content blocks.
-- [ ] Admin dashboard overview with key metrics (open orders, recent orders, low-stock, sales last 30d).
-- [ ] Admin tools for inline/bulk stock editing in product table.
+- [x] Live preview mode in admin for page changes before publishing.
+- [x] Version metadata (“last updated by/at”) for content blocks.
+- [x] Admin dashboard overview with key metrics (open orders, recent orders, low-stock, sales last 30d).
+- [x] Admin tools for inline/bulk stock editing in product table.
 - [ ] Duplicate product action in admin (clone with images, mark draft).
 - [ ] Admin controls for bestseller/highlight badges on storefront cards.
 - [ ] Scheduling for product publish/unpublish; show upcoming scheduled products.


### PR DESCRIPTION
**Summary**
- Add admin controls for global assets, per-page SEO, and content previews.
- Show content version metadata and enhance dashboard metrics.
- Provide inline and bulk stock editing for products.

**Changes**
- Admin page now loads/saves site assets (logo, favicon, social image) via content blocks.
- Added SEO editor per page (home/shop/product/category/about) with language toggle and content block storage.
- Added RO/EN editors for About/FAQ/Shipping with live preview option.
- Display content version/update info; added extra dashboard metrics cards.
- Added inline stock inputs plus bulk stock apply for selected products.
- TODO updated accordingly.

**Testing**
- `npm run build` (passes; existing bundle budget warning remains).

**Risk & Impact**
- Frontend-only changes; uses existing content endpoints. Bundle size still slightly over configured budget.

**Related TODO items**
- [x] Admin UI for global assets (logo, favicon, social preview image).
- [x] SEO settings in admin to set meta title/description per page per language.
- [x] WYSIWYG/markdown editor for About/FAQ/Shipping content with RO/EN tabs.
- [x] Live preview mode in admin for page changes before publishing.
- [x] Version metadata (“last updated by/at”) for content blocks.
- [x] Admin dashboard overview with key metrics (open orders, recent orders, low-stock, sales last 30d).
- [x] Admin tools for inline/bulk stock editing in product table.
