### PR TITLE
feat: add wishlist UI

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -410,7 +410,7 @@ Below is a structured checklist you can turn into issues.
 - [x] Payments: add tests for Stripe webhook signature validation (STRIPE_WEBHOOK_SECRET), including invalid signatures.
 - [x] Payments: add webhook idempotency (store processed event IDs) to avoid double-processing.
 - [x] Infra: add docker-compose healthchecks and `depends_on` conditions (db → backend → frontend).
-- [ ] Frontend: add Wishlist UI (product list/detail + account) and wire it to the backend wishlist endpoints.
+- [x] Frontend: add Wishlist UI (product list/detail + account) and wire it to the backend wishlist endpoints.
 - [ ] Testing: run core API flows against Postgres (Docker) in CI to catch SQL dialect issues.
 
 ### Low priority

--- a/frontend/src/app/core/wishlist.service.ts
+++ b/frontend/src/app/core/wishlist.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, computed, signal } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ApiService } from './api.service';
+import { AuthService } from './auth.service';
+import { Product } from './catalog.service';
+
+@Injectable({ providedIn: 'root' })
+export class WishlistService {
+  private readonly itemsSignal = signal<Product[]>([]);
+  readonly items = this.itemsSignal.asReadonly();
+  readonly ids = computed(() => new Set(this.itemsSignal().map((p) => p.id)));
+
+  private loaded = false;
+  private loading = false;
+
+  constructor(
+    private api: ApiService,
+    private auth: AuthService
+  ) {}
+
+  isLoaded(): boolean {
+    return this.loaded;
+  }
+
+  ensureLoaded(): void {
+    if (this.loaded || this.loading) return;
+    if (!this.auth.isAuthenticated()) return;
+    this.loading = true;
+    this.api.get<Product[]>('/wishlist').subscribe({
+      next: (items) => {
+        this.itemsSignal.set(items);
+        this.loaded = true;
+        this.loading = false;
+      },
+      error: () => {
+        this.itemsSignal.set([]);
+        this.loaded = true;
+        this.loading = false;
+      }
+    });
+  }
+
+  refresh(): void {
+    this.loaded = false;
+    this.ensureLoaded();
+  }
+
+  clear(): void {
+    this.itemsSignal.set([]);
+    this.loaded = false;
+    this.loading = false;
+  }
+
+  isWishlisted(productId: string): boolean {
+    return this.ids().has(productId);
+  }
+
+  add(productId: string): Observable<Product> {
+    return this.api.post<Product>(`/wishlist/${productId}`, {});
+  }
+
+  remove(productId: string): Observable<void> {
+    return this.api.delete<void>(`/wishlist/${productId}`);
+  }
+
+  addLocal(product: Product): void {
+    this.itemsSignal.update((items) => {
+      if (items.some((p) => p.id === product.id)) return items;
+      return [...items, product];
+    });
+  }
+
+  removeLocal(productId: string): void {
+    this.itemsSignal.update((items) => items.filter((p) => p.id !== productId));
+  }
+}

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -372,5 +372,17 @@
       "hint": "Below 5 units",
       "stock": "Stock: {{count}}"
     }
+  },
+  "wishlist": {
+    "add": "Add to wishlist",
+    "remove": "Remove from wishlist",
+    "save": "Save",
+    "saved": "Saved",
+    "signInTitle": "Sign in required",
+    "signInBody": "Please sign in to save items to your wishlist.",
+    "addedTitle": "Saved to wishlist",
+    "addedBody": "{{name}} was added to your wishlist.",
+    "removedTitle": "Removed from wishlist",
+    "removedBody": "{{name}} was removed from your wishlist."
   }
 }

--- a/frontend/src/assets/i18n/ro.json
+++ b/frontend/src/assets/i18n/ro.json
@@ -372,5 +372,17 @@
       "hint": "Sub 5 unități",
       "stock": "Stoc: {{count}}"
     }
+  },
+  "wishlist": {
+    "add": "Adaugă la favorite",
+    "remove": "Elimină din favorite",
+    "save": "Salvează",
+    "saved": "Salvat",
+    "signInTitle": "Autentificare necesară",
+    "signInBody": "Autentifică-te pentru a salva produse la favorite.",
+    "addedTitle": "Adăugat la favorite",
+    "addedBody": "{{name}} a fost adăugat la favorite.",
+    "removedTitle": "Eliminat din favorite",
+    "removedBody": "{{name}} a fost eliminat din favorite."
   }
 }


### PR DESCRIPTION
- **Summary**
  - Adds a Wishlist feature in the Angular frontend and wires it to the existing backend `/api/v1/wishlist` endpoints.

- **Changes**
  - Add `frontend/src/app/core/wishlist.service.ts` to load and manage wishlist state.
  - Add a wishlist toggle to `frontend/src/app/shared/product-card.component.ts` and `frontend/src/app/pages/product/product.component.ts`.
  - Add a Wishlist section to `frontend/src/app/pages/account/account.component.ts`.
  - Add new i18n strings for wishlist actions/toasts.
  - Update `TODO.md` to mark the Wishlist UI item complete.

- **Testing**
  - `cd frontend && npm run lint`
  - `cd frontend && npm run build`

- **Risk & Impact**
  - No backend changes; depends on existing authenticated wishlist endpoints.

- **Related TODO items**
  - [x] Frontend: add Wishlist UI (product list/detail + account) and wire it to the backend wishlist endpoints.