### PR TITLE
fix: improve theme switching and dark-mode UX

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -391,6 +391,12 @@ Below is a structured checklist you can turn into issues.
 - [x] robots.txt and sitemap.xml generation (with i18n URLs).
 - [x] Per-language canonical URLs for product pages.
 - [x] Document “local-only dev” mode (SQLite + local media + Stripe test) and “prod-like” mode (Postgres + S3 + SMTP).
+- [x] Fix theme switching to override system (Tailwind `darkMode: 'class'`) and sync `color-scheme` to match selected theme.
+- [x] UX: prevent toast notifications from blocking interactions and dedupe repeated error toasts.
+- [x] UX: make Stripe CardElement readable in dark mode and update styles on theme changes (checkout + account).
+- [x] Perf: fix account idle-timer event listener cleanup (avoid leaking listeners with `.bind(this)`).
+- [ ] Follow-up: set `<meta name="theme-color">` dynamically based on selected theme (mobile address bar).
+- [ ] Follow-up: add early theme bootstrap in `frontend/src/index.html` to avoid flash of incorrect theme on load.
 
 ## Backlog (New ideas inspired by Event Link)
 

--- a/frontend/src/app/core/toast.service.ts
+++ b/frontend/src/app/core/toast.service.ts
@@ -31,6 +31,11 @@ export class ToastService {
   }
 
   private push(message: Omit<ToastMessage, 'id'>): void {
+    const hasDuplicate = this.messagesSignal().some(
+      (existing) =>
+        existing.title === message.title && existing.description === message.description && existing.tone === message.tone
+    );
+    if (hasDuplicate) return;
     const id = uuidv4();
     this.messagesSignal.update((msgs) => [...msgs, { id, ...message }]);
     setTimeout(() => this.clear(id), 4000);

--- a/frontend/src/app/pages/account/account.component.ts
+++ b/frontend/src/app/pages/account/account.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit, AfterViewInit, OnDestroy, signal, ViewChild, ElementRef } from '@angular/core';
+import { Component, OnInit, AfterViewInit, OnDestroy, signal, ViewChild, ElementRef, effect, EffectRef } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { ContainerComponent } from '../../layout/container.component';
@@ -16,6 +16,7 @@ import { ApiService } from '../../core/api.service';
 import { appConfig } from '../../core/app-config';
 import { WishlistService } from '../../core/wishlist.service';
 import { ProductCardComponent } from '../../shared/product-card.component';
+import { ThemeMode, ThemeService } from '../../core/theme.service';
 
 @Component({
   selector: 'app-account',
@@ -35,11 +36,11 @@ import { ProductCardComponent } from '../../shared/product-card.component';
     <app-container classes="py-10 grid gap-6">
       <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
       <ng-container *ngIf="!loading(); else loadingTpl">
-        <div *ngIf="error()" class="rounded-lg bg-rose-50 border border-rose-200 text-rose-800 p-3 text-sm">
+        <div *ngIf="error()" class="rounded-lg bg-rose-50 border border-rose-200 text-rose-800 p-3 text-sm dark:border-rose-900/40 dark:bg-rose-950/30 dark:text-rose-100">
           {{ error() }}
         </div>
         <div class="grid gap-6" *ngIf="!error()">
-        <div *ngIf="!emailVerified()" class="rounded-xl border border-amber-200 bg-amber-50 p-3 text-amber-900 text-sm grid gap-3">
+        <div *ngIf="!emailVerified()" class="rounded-xl border border-amber-200 bg-amber-50 p-3 text-amber-900 text-sm grid gap-3 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100">
           <div class="flex items-start justify-between gap-3">
             <span>Verify your email to secure your account and receive updates.</span>
             <app-button size="sm" variant="ghost" label="Resend link" (action)="resendVerification()"></app-button>
@@ -50,44 +51,44 @@ import { ProductCardComponent } from '../../shared/product-card.component';
               name="verificationToken"
               type="text"
               placeholder="Enter verification token"
-              class="border border-amber-300 rounded-lg px-3 py-2 text-sm flex-1"
+              class="border border-amber-300 bg-white rounded-lg px-3 py-2 text-sm flex-1 text-slate-900 dark:border-amber-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-400"
               required
             />
             <app-button size="sm" label="Confirm" type="submit"></app-button>
           </form>
-          <p *ngIf="verificationStatus" class="text-xs text-amber-800">{{ verificationStatus }}</p>
+          <p *ngIf="verificationStatus" class="text-xs text-amber-800 dark:text-amber-200">{{ verificationStatus }}</p>
         </div>
         <header class="flex items-center justify-between">
           <div>
-            <p class="text-sm text-slate-500">Signed in as</p>
-            <h1 class="text-2xl font-semibold text-slate-900">{{ profile()?.email || '...' }}</h1>
+            <p class="text-sm text-slate-500 dark:text-slate-400">Signed in as</p>
+            <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-50">{{ profile()?.email || '...' }}</h1>
           </div>
           <app-button routerLink="/account/password" variant="ghost" label="Change password"></app-button>
         </header>
 
-        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
           <div class="flex items-center justify-between">
-            <h2 class="text-lg font-semibold text-slate-900">Profile</h2>
+            <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">Profile</h2>
             <app-button size="sm" variant="ghost" label="Save"></app-button>
           </div>
           <div class="flex items-center gap-4">
-            <img [src]="avatar || placeholderAvatar" alt="avatar" class="h-16 w-16 rounded-full object-cover border" />
-            <label class="text-sm text-indigo-600 font-medium cursor-pointer">
+            <img [src]="avatar || placeholderAvatar" alt="avatar" class="h-16 w-16 rounded-full object-cover border border-slate-200 dark:border-slate-800" />
+            <label class="text-sm text-indigo-600 font-medium cursor-pointer dark:text-indigo-300">
               Upload avatar
               <input type="file" class="hidden" accept="image/*" (change)="onAvatarChange($event)" />
             </label>
         </div>
-        <p class="text-sm text-slate-700">Name: {{ profile()?.name || 'Not set' }}</p>
-        <p class="text-sm text-slate-700">Email: {{ profile()?.email || '...' }}</p>
-        <p class="text-sm text-slate-600">Session timeout: 30m. <a class="text-indigo-600" (click)="signOut()">Sign out</a></p>
+        <p class="text-sm text-slate-700 dark:text-slate-200">Name: {{ profile()?.name || 'Not set' }}</p>
+        <p class="text-sm text-slate-700 dark:text-slate-200">Email: {{ profile()?.email || '...' }}</p>
+        <p class="text-sm text-slate-600 dark:text-slate-300">Session timeout: 30m. <a class="text-indigo-600 dark:text-indigo-300" (click)="signOut()">Sign out</a></p>
         </section>
 
-        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
           <div class="flex items-center justify-between">
-            <h2 class="text-lg font-semibold text-slate-900">Connected accounts</h2>
+            <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">Connected accounts</h2>
             <span
               class="text-xs rounded-full px-2 py-1"
-              [ngClass]="googleEmail() ? 'bg-emerald-100 text-emerald-800' : 'bg-slate-100 text-slate-700'"
+              [ngClass]="googleEmail() ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-100' : 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200'"
             >
               {{ googleEmail() ? 'Google linked' : 'Not linked' }}
             </span>
@@ -97,11 +98,11 @@ import { ProductCardComponent } from '../../shared/product-card.component';
               *ngIf="googlePicture()"
               [src]="googlePicture()"
               alt="Google profile"
-              class="h-10 w-10 rounded-full border object-cover"
+              class="h-10 w-10 rounded-full border border-slate-200 dark:border-slate-700 object-cover"
             />
             <div>
-              <p class="font-semibold text-slate-900">Google</p>
-              <p class="text-slate-600">{{ googleEmail() || 'No Google account linked' }}</p>
+              <p class="font-semibold text-slate-900 dark:text-slate-50">Google</p>
+              <p class="text-slate-600 dark:text-slate-300">{{ googleEmail() || 'No Google account linked' }}</p>
             </div>
             <div class="flex gap-2 ml-auto">
               <app-button size="sm" variant="ghost" label="Link Google" *ngIf="!googleEmail()" (action)="linkGoogle()"></app-button>
@@ -110,25 +111,25 @@ import { ProductCardComponent } from '../../shared/product-card.component';
           </div>
         </section>
 
-        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
           <div class="flex items-center justify-between">
-            <h2 class="text-lg font-semibold text-slate-900">Addresses</h2>
+            <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">Addresses</h2>
             <app-button size="sm" variant="ghost" label="Add address" (action)="openAddressForm()"></app-button>
           </div>
-          <div *ngIf="showAddressForm" class="rounded-lg border border-slate-200 p-3">
+          <div *ngIf="showAddressForm" class="rounded-lg border border-slate-200 p-3 dark:border-slate-700">
             <app-address-form
               [model]="addressModel"
               (save)="saveAddress($event)"
               (cancel)="closeAddressForm()"
             ></app-address-form>
           </div>
-          <div *ngIf="addresses().length === 0 && !showAddressForm" class="text-sm text-slate-700">No addresses yet.</div>
-          <div *ngFor="let addr of addresses()" class="rounded-lg border border-slate-200 p-3 grid gap-1 text-sm text-slate-700">
+          <div *ngIf="addresses().length === 0 && !showAddressForm" class="text-sm text-slate-700 dark:text-slate-200">No addresses yet.</div>
+          <div *ngFor="let addr of addresses()" class="rounded-lg border border-slate-200 p-3 grid gap-1 text-sm text-slate-700 dark:border-slate-700 dark:text-slate-200">
             <div class="flex items-center justify-between">
-              <span class="font-semibold text-slate-900">{{ addr.label || 'Address' }}</span>
+              <span class="font-semibold text-slate-900 dark:text-slate-50">{{ addr.label || 'Address' }}</span>
               <div class="flex items-center gap-2 text-xs">
-                <span *ngIf="addr.is_default_shipping" class="rounded-full bg-slate-100 px-2 py-0.5">Default shipping</span>
-                <span *ngIf="addr.is_default_billing" class="rounded-full bg-slate-100 px-2 py-0.5">Default billing</span>
+                <span *ngIf="addr.is_default_shipping" class="rounded-full bg-slate-100 px-2 py-0.5 dark:bg-slate-800">Default shipping</span>
+                <span *ngIf="addr.is_default_billing" class="rounded-full bg-slate-100 px-2 py-0.5 dark:bg-slate-800">Default billing</span>
               </div>
               <div class="flex gap-2">
                 <app-button size="sm" variant="ghost" label="Edit" (action)="editAddress(addr)"></app-button>
@@ -141,40 +142,40 @@ import { ProductCardComponent } from '../../shared/product-card.component';
           </div>
         </section>
 
-	        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
-	          <div class="flex items-center justify-between">
-	            <h2 class="text-lg font-semibold text-slate-900">Orders</h2>
-	            <a routerLink="/shop" class="text-sm text-indigo-600 font-medium">Shop new items</a>
-          </div>
-          <div class="flex items-center gap-3 text-sm">
-            <label class="flex items-center gap-1">
-              Status
-              <select class="rounded-lg border border-slate-200 px-2 py-1" [(ngModel)]="orderFilter" (change)="filterOrders()">
-                <option value="">All</option>
-                <option value="pending">Pending</option>
-                <option value="paid">Paid</option>
-                <option value="shipped">Shipped</option>
-                <option value="cancelled">Cancelled</option>
-                <option value="refunded">Refunded</option>
-              </select>
-            </label>
-          </div>
-          <div *ngIf="pagedOrders().length === 0" class="border border-dashed border-slate-200 rounded-xl p-4 text-sm text-slate-600">
-            No orders yet.
-          </div>
-          <div *ngFor="let order of pagedOrders()" class="rounded-lg border border-slate-200 p-3 grid gap-1 text-sm text-slate-700">
-            <div class="flex items-center justify-between">
-              <span class="font-semibold text-slate-900">Order #{{ order.reference_code || order.id }}</span>
-              <span class="text-xs rounded-full bg-slate-100 px-2 py-1">{{ order.status }}</span>
-            </div>
-            <span>{{ order.created_at | date: 'mediumDate' }}</span>
-            <span class="font-semibold text-slate-900">{{ order.total_amount | localizedCurrency : order.currency || 'USD' }}</span>
-          </div>
-          <div class="flex items-center justify-between text-sm" *ngIf="pagedOrders().length">
-            <span>Page {{ page }} / {{ totalPages }}</span>
-            <div class="flex gap-2">
-              <app-button size="sm" variant="ghost" label="Prev" [disabled]="page === 1" (action)="prevPage()"></app-button>
-              <app-button
+		        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+		          <div class="flex items-center justify-between">
+		            <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">Orders</h2>
+		            <a routerLink="/shop" class="text-sm text-indigo-600 dark:text-indigo-300 font-medium">Shop new items</a>
+	          </div>
+	          <div class="flex items-center gap-3 text-sm">
+	            <label class="flex items-center gap-1">
+	              Status
+	              <select class="rounded-lg border border-slate-200 bg-white px-2 py-1 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [(ngModel)]="orderFilter" (change)="filterOrders()">
+	                <option value="">All</option>
+	                <option value="pending">Pending</option>
+	                <option value="paid">Paid</option>
+	                <option value="shipped">Shipped</option>
+	                <option value="cancelled">Cancelled</option>
+	                <option value="refunded">Refunded</option>
+	              </select>
+	            </label>
+	          </div>
+	          <div *ngIf="pagedOrders().length === 0" class="border border-dashed border-slate-200 rounded-xl p-4 text-sm text-slate-600 dark:border-slate-700 dark:text-slate-300">
+	            No orders yet.
+	          </div>
+	          <div *ngFor="let order of pagedOrders()" class="rounded-lg border border-slate-200 p-3 grid gap-1 text-sm text-slate-700 dark:border-slate-700 dark:text-slate-200">
+	            <div class="flex items-center justify-between">
+	              <span class="font-semibold text-slate-900 dark:text-slate-50">Order #{{ order.reference_code || order.id }}</span>
+	              <span class="text-xs rounded-full bg-slate-100 px-2 py-1 dark:bg-slate-800">{{ order.status }}</span>
+	            </div>
+	            <span>{{ order.created_at | date: 'mediumDate' }}</span>
+	            <span class="font-semibold text-slate-900 dark:text-slate-50">{{ order.total_amount | localizedCurrency : order.currency || 'USD' }}</span>
+	          </div>
+	          <div class="flex items-center justify-between text-sm text-slate-700 dark:text-slate-200" *ngIf="pagedOrders().length">
+	            <span>Page {{ page }} / {{ totalPages }}</span>
+	            <div class="flex gap-2">
+	              <app-button size="sm" variant="ghost" label="Prev" [disabled]="page === 1" (action)="prevPage()"></app-button>
+	              <app-button
                 size="sm"
                 variant="ghost"
                 label="Next"
@@ -183,39 +184,39 @@ import { ProductCardComponent } from '../../shared/product-card.component';
               ></app-button>
             </div>
 	          </div>
-	        </section>
+		        </section>
 
-	        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
-	          <div class="flex items-center justify-between">
-	            <h2 class="text-lg font-semibold text-slate-900">Wishlist</h2>
-	            <a routerLink="/shop" class="text-sm text-indigo-600 font-medium">Browse products</a>
-	          </div>
-	          <div
-	            *ngIf="wishlist.items().length === 0"
-	            class="border border-dashed border-slate-200 rounded-xl p-4 text-sm text-slate-600"
-	          >
-	            No saved items yet.
-	          </div>
-	          <div *ngIf="wishlist.items().length" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-	            <app-product-card *ngFor="let item of wishlist.items()" [product]="item"></app-product-card>
-	          </div>
-	        </section>
+		        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+		          <div class="flex items-center justify-between">
+		            <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">Wishlist</h2>
+		            <a routerLink="/shop" class="text-sm text-indigo-600 dark:text-indigo-300 font-medium">Browse products</a>
+		          </div>
+		          <div
+		            *ngIf="wishlist.items().length === 0"
+		            class="border border-dashed border-slate-200 rounded-xl p-4 text-sm text-slate-600 dark:border-slate-700 dark:text-slate-300"
+		          >
+		            No saved items yet.
+		          </div>
+		          <div *ngIf="wishlist.items().length" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+		            <app-product-card *ngFor="let item of wishlist.items()" [product]="item"></app-product-card>
+		          </div>
+		        </section>
 
-	        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
-	          <div class="flex items-center justify-between">
-	            <h2 class="text-lg font-semibold text-slate-900">Payment methods</h2>
-	            <div class="flex gap-2 items-center">
+		        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+		          <div class="flex items-center justify-between">
+		            <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">Payment methods</h2>
+		            <div class="flex gap-2 items-center">
               <app-button size="sm" variant="ghost" label="Add card" (action)="startAddCard()"></app-button>
               <app-button size="sm" label="Save card" (action)="confirmCard()" [disabled]="!cardReady || savingCard"></app-button>
             </div>
           </div>
-          <div *ngIf="paymentMethods.length === 0" class="text-sm text-slate-700">No cards saved yet.</div>
-          <div class="border border-dashed border-slate-200 rounded-lg p-3 text-sm" *ngIf="cardElementVisible">
-            <p class="text-slate-600 mb-2">Enter card details:</p>
+          <div *ngIf="paymentMethods.length === 0" class="text-sm text-slate-700 dark:text-slate-200">No cards saved yet.</div>
+          <div class="border border-dashed border-slate-200 rounded-lg p-3 text-sm dark:border-slate-700" *ngIf="cardElementVisible">
+            <p class="text-slate-600 dark:text-slate-300 mb-2">Enter card details:</p>
             <div #cardHost id="card-element" class="min-h-[48px]"></div>
-            <p *ngIf="cardError" class="text-rose-700 text-xs mt-2">{{ cardError }}</p>
+            <p *ngIf="cardError" class="text-rose-700 dark:text-rose-300 text-xs mt-2">{{ cardError }}</p>
           </div>
-          <div *ngFor="let pm of paymentMethods" class="flex items-center justify-between text-sm border border-slate-200 rounded-lg p-3">
+          <div *ngFor="let pm of paymentMethods" class="flex items-center justify-between text-sm border border-slate-200 rounded-lg p-3 dark:border-slate-700">
             <div class="flex items-center gap-2">
               <span class="font-semibold">{{ pm.brand || 'Card' }}</span>
               <span *ngIf="pm.last4">•••• {{ pm.last4 }}</span>
@@ -225,19 +226,19 @@ import { ProductCardComponent } from '../../shared/product-card.component';
           </div>
         </section>
 
-        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
-          <h2 class="text-lg font-semibold text-slate-900">Session</h2>
-          <p class="text-sm text-slate-700">
-            You will be logged out after inactivity to keep your account safe. <a class="text-indigo-600" (click)="signOut()">Logout now</a>.
-          </p>
-          <div class="flex gap-2">
-            <app-button size="sm" variant="ghost" label="Refresh session" (action)="refreshSession()"></app-button>
-          </div>
-        </section>
+	        <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+	          <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">Session</h2>
+	          <p class="text-sm text-slate-700 dark:text-slate-200">
+	            You will be logged out after inactivity to keep your account safe. <a class="text-indigo-600 dark:text-indigo-300" (click)="signOut()">Logout now</a>.
+	          </p>
+	          <div class="flex gap-2">
+	            <app-button size="sm" variant="ghost" label="Refresh session" (action)="refreshSession()"></app-button>
+	          </div>
+	        </section>
       </div>
       </ng-container>
       <ng-template #loadingTpl>
-        <div class="text-sm text-slate-600">Loading your account...</div>
+        <div class="text-sm text-slate-600 dark:text-slate-300">Loading your account...</div>
       </ng-template>
     </app-container>
   `
@@ -276,6 +277,7 @@ export class AccountComponent implements OnInit, AfterViewInit, OnDestroy {
   private card?: StripeCardElement;
   private clientSecret: string | null = null;
   @ViewChild('cardHost') cardElementRef?: ElementRef<HTMLDivElement>;
+  private stripeThemeEffect?: EffectRef;
   showAddressForm = false;
   editingAddressId: string | null = null;
   addressModel: AddressCreateRequest = {
@@ -285,6 +287,7 @@ export class AccountComponent implements OnInit, AfterViewInit, OnDestroy {
     country: 'US'
   };
   private idleTimer?: any;
+  private readonly handleUserActivity = () => this.resetIdleTimer();
   idleWarning = signal<string | null>(null);
 
   constructor(
@@ -293,9 +296,16 @@ export class AccountComponent implements OnInit, AfterViewInit, OnDestroy {
     private account: AccountService,
     private router: Router,
     private api: ApiService,
-    public wishlist: WishlistService
+    public wishlist: WishlistService,
+    private theme: ThemeService
   ) {
     this.computeTotalPages();
+    this.stripeThemeEffect = effect(() => {
+      const mode = this.theme.mode()();
+      if (this.card) {
+        this.card.update({ style: this.buildStripeCardStyle(mode) });
+      }
+    });
   }
 
   ngOnInit(): void {
@@ -303,8 +313,8 @@ export class AccountComponent implements OnInit, AfterViewInit, OnDestroy {
     this.loadData();
     this.loadPaymentMethods();
     this.resetIdleTimer();
-    window.addEventListener('mousemove', this.resetIdleTimer.bind(this));
-    window.addEventListener('keydown', this.resetIdleTimer.bind(this));
+    window.addEventListener('mousemove', this.handleUserActivity);
+    window.addEventListener('keydown', this.handleUserActivity);
   }
 
   async ngAfterViewInit(): Promise<void> {
@@ -516,8 +526,9 @@ export class AccountComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.card) {
       this.card.destroy();
     }
-    window.removeEventListener('mousemove', this.resetIdleTimer.bind(this));
-    window.removeEventListener('keydown', this.resetIdleTimer.bind(this));
+    this.stripeThemeEffect?.destroy();
+    window.removeEventListener('mousemove', this.handleUserActivity);
+    window.removeEventListener('keydown', this.handleUserActivity);
   }
 
   private async setupStripe(): Promise<void> {
@@ -533,8 +544,33 @@ export class AccountComponent implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
     this.elements = this.stripe.elements();
-    this.card = this.elements.create('card');
+    this.card = this.elements.create('card', { style: this.buildStripeCardStyle(this.theme.mode()()) });
     this.mountCardElement();
+  }
+
+  private buildStripeCardStyle(mode: ThemeMode) {
+    const base =
+      mode === 'dark'
+        ? {
+            color: '#f8fafc',
+            iconColor: '#f8fafc',
+            fontFamily: 'Inter, system-ui, sans-serif',
+            fontSize: '16px',
+            '::placeholder': { color: '#94a3b8' }
+          }
+        : {
+            color: '#0f172a',
+            iconColor: '#0f172a',
+            fontFamily: 'Inter, system-ui, sans-serif',
+            fontSize: '16px',
+            '::placeholder': { color: '#64748b' }
+          };
+    return {
+      base,
+      invalid: {
+        color: mode === 'dark' ? '#fca5a5' : '#b91c1c'
+      }
+    };
   }
 
   private getStripePublishableKey(): string | null {

--- a/frontend/src/app/pages/account/change-password.component.ts
+++ b/frontend/src/app/pages/account/change-password.component.ts
@@ -15,42 +15,42 @@ import { AuthService } from '../../core/auth.service';
   template: `
     <app-container classes="py-10 grid gap-6 max-w-xl">
       <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
-      <h1 class="text-2xl font-semibold text-slate-900">Change password</h1>
+      <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-50">Change password</h1>
       <form #changeForm="ngForm" class="grid gap-4" (ngSubmit)="onSubmit(changeForm)">
-        <label class="grid gap-1 text-sm font-medium text-slate-700">
+        <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           Current password
           <input
             name="current"
             type="password"
-            class="rounded-lg border border-slate-200 px-3 py-2"
+            class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
             required
             [(ngModel)]="current"
           />
         </label>
-        <label class="grid gap-1 text-sm font-medium text-slate-700">
+        <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           New password
           <input
             name="password"
             type="password"
-            class="rounded-lg border border-slate-200 px-3 py-2"
+            class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
             required
             minlength="6"
             [(ngModel)]="password"
           />
         </label>
-        <label class="grid gap-1 text-sm font-medium text-slate-700">
+        <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           Confirm new password
           <input
             name="confirm"
             type="password"
-            class="rounded-lg border border-slate-200 px-3 py-2"
+            class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
             required
             [(ngModel)]="confirm"
           />
         </label>
-        <p *ngIf="error" class="text-sm text-amber-700">{{ error }}</p>
+        <p *ngIf="error" class="text-sm text-amber-700 dark:text-amber-300">{{ error }}</p>
         <app-button label="Update password" type="submit"></app-button>
-        <a routerLink="/account" class="text-sm text-indigo-600 font-medium">Back to account</a>
+        <a routerLink="/account" class="text-sm text-indigo-600 dark:text-indigo-300 font-medium">Back to account</a>
       </form>
     </app-container>
   `

--- a/frontend/src/app/pages/admin/admin.component.ts
+++ b/frontend/src/app/pages/admin/admin.component.ts
@@ -43,24 +43,24 @@ import { firstValueFrom } from 'rxjs';
     SkeletonComponent,
     TranslateModule
   ],
-  template: `
+ template: `
     <app-container classes="py-8 grid gap-6">
       <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
-      <div *ngIf="error()" class="rounded-lg bg-rose-50 border border-rose-200 text-rose-800 p-3 text-sm">
+      <div *ngIf="error()" class="rounded-lg bg-rose-50 border border-rose-200 text-rose-800 p-3 text-sm dark:border-rose-900/40 dark:bg-rose-950/30 dark:text-rose-100">
         {{ error() }}
       </div>
       <div class="grid lg:grid-cols-[260px_1fr] gap-6">
-        <aside class="rounded-2xl border border-slate-200 bg-white p-4 grid gap-2 text-sm text-slate-700">
-          <a class="font-semibold text-slate-900">{{ 'adminUi.nav.dashboard' | translate }}</a>
-          <a class="hover:text-slate-900 text-slate-700">{{ 'adminUi.nav.products' | translate }}</a>
-          <a class="hover:text-slate-900 text-slate-700">{{ 'adminUi.nav.orders' | translate }}</a>
-          <a class="hover:text-slate-900 text-slate-700">{{ 'adminUi.nav.users' | translate }}</a>
-          <a class="hover:text-slate-900 text-slate-700">{{ 'adminUi.nav.content' | translate }}</a>
+        <aside class="rounded-2xl border border-slate-200 bg-white p-4 grid gap-2 text-sm text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200">
+          <a class="font-semibold text-slate-900 dark:text-slate-50">{{ 'adminUi.nav.dashboard' | translate }}</a>
+          <a class="hover:text-slate-900 text-slate-700 dark:text-slate-200 dark:hover:text-white">{{ 'adminUi.nav.products' | translate }}</a>
+          <a class="hover:text-slate-900 text-slate-700 dark:text-slate-200 dark:hover:text-white">{{ 'adminUi.nav.orders' | translate }}</a>
+          <a class="hover:text-slate-900 text-slate-700 dark:text-slate-200 dark:hover:text-white">{{ 'adminUi.nav.users' | translate }}</a>
+          <a class="hover:text-slate-900 text-slate-700 dark:text-slate-200 dark:hover:text-white">{{ 'adminUi.nav.content' | translate }}</a>
         </aside>
 
         <div class="grid gap-6" *ngIf="!loading(); else loadingTpl">
           <section class="grid gap-3">
-            <h1 class="text-2xl font-semibold text-slate-900">{{ 'adminUi.dashboardTitle' | translate }}</h1>
+            <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-50">{{ 'adminUi.dashboardTitle' | translate }}</h1>
             <div class="grid md:grid-cols-3 gap-4">
               <app-card [title]="'adminUi.cards.products' | translate" [subtitle]="summary()?.products + ' total'"></app-card>
               <app-card [title]="'adminUi.cards.orders' | translate" [subtitle]="summary()?.orders + ' total'"></app-card>
@@ -76,9 +76,9 @@ import { firstValueFrom } from 'rxjs';
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">Global assets</h2>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">Global assets</h2>
               <app-button size="sm" variant="ghost" label="Reload" (action)="loadAssets()"></app-button>
             </div>
             <div class="grid md:grid-cols-3 gap-3 text-sm">
@@ -88,18 +88,18 @@ import { firstValueFrom } from 'rxjs';
             </div>
             <div class="flex items-center gap-2 text-sm">
               <app-button size="sm" label="Save assets" (action)="saveAssets()"></app-button>
-              <span class="text-xs text-emerald-700" *ngIf="assetsMessage">{{ assetsMessage }}</span>
-              <span class="text-xs text-rose-700" *ngIf="assetsError">{{ assetsError }}</span>
+              <span class="text-xs text-emerald-700 dark:text-emerald-300" *ngIf="assetsMessage">{{ assetsMessage }}</span>
+              <span class="text-xs text-rose-700 dark:text-rose-300" *ngIf="assetsError">{{ assetsError }}</span>
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">SEO meta (per page & language)</h2>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">SEO meta (per page & language)</h2>
               <div class="flex gap-2 text-sm">
                 <label class="flex items-center gap-2">
                   Page
-                  <select class="rounded border border-slate-200 px-2 py-1" [(ngModel)]="seoPage" (ngModelChange)="loadSeo()">
+                  <select class="rounded border border-slate-200 bg-white px-2 py-1 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [(ngModel)]="seoPage" (ngModelChange)="loadSeo()">
                     <option value="home">Home</option>
                     <option value="shop">Shop</option>
                     <option value="product">Product</option>
@@ -119,21 +119,21 @@ import { firstValueFrom } from 'rxjs';
             </div>
             <div class="grid md:grid-cols-2 gap-3 text-sm">
               <app-input label="Meta title" [(value)]="seoForm.title"></app-input>
-              <label class="grid text-sm font-medium text-slate-700 md:col-span-2">
+              <label class="grid text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
                 Meta description
-                <textarea rows="2" class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="seoForm.description"></textarea>
+                <textarea rows="2" class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [(ngModel)]="seoForm.description"></textarea>
               </label>
             </div>
             <div class="flex items-center gap-2 text-sm">
               <app-button size="sm" label="Save SEO" (action)="saveSeo()"></app-button>
-              <span class="text-xs text-emerald-700" *ngIf="seoMessage">{{ seoMessage }}</span>
-              <span class="text-xs text-rose-700" *ngIf="seoError">{{ seoError }}</span>
+              <span class="text-xs text-emerald-700 dark:text-emerald-300" *ngIf="seoMessage">{{ seoMessage }}</span>
+              <span class="text-xs text-rose-700 dark:text-rose-300" *ngIf="seoError">{{ seoError }}</span>
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">Static pages (RO/EN)</h2>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">Static pages (RO/EN)</h2>
               <div class="flex gap-2 text-sm">
                 <button class="px-3 py-1 rounded border" [class.bg-slate-900]="infoLang === 'en'" [class.text-white]="infoLang === 'en'" (click)="selectInfoLang('en')">
                   EN
@@ -144,35 +144,35 @@ import { firstValueFrom } from 'rxjs';
               </div>
             </div>
             <div class="grid gap-3 text-sm">
-              <label class="grid gap-1 font-medium text-slate-700">
+              <label class="grid gap-1 font-medium text-slate-700 dark:text-slate-200">
                 About content
-                <textarea rows="3" class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="infoForm.about"></textarea>
+                <textarea rows="3" class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [(ngModel)]="infoForm.about"></textarea>
               </label>
               <div class="flex gap-2">
                 <app-button size="sm" label="Save About" (action)="saveInfo('page.about', infoForm.about)"></app-button>
               </div>
-              <label class="grid gap-1 font-medium text-slate-700">
+              <label class="grid gap-1 font-medium text-slate-700 dark:text-slate-200">
                 FAQ content
-                <textarea rows="3" class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="infoForm.faq"></textarea>
+                <textarea rows="3" class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [(ngModel)]="infoForm.faq"></textarea>
               </label>
               <div class="flex gap-2">
                 <app-button size="sm" label="Save FAQ" (action)="saveInfo('page.faq', infoForm.faq)"></app-button>
               </div>
-              <label class="grid gap-1 font-medium text-slate-700">
+              <label class="grid gap-1 font-medium text-slate-700 dark:text-slate-200">
                 Shipping/Returns content
-                <textarea rows="3" class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="infoForm.shipping"></textarea>
+                <textarea rows="3" class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [(ngModel)]="infoForm.shipping"></textarea>
               </label>
               <div class="flex gap-2">
                 <app-button size="sm" label="Save Shipping" (action)="saveInfo('page.shipping', infoForm.shipping)"></app-button>
-                <span class="text-xs text-emerald-700" *ngIf="infoMessage">{{ infoMessage }}</span>
-                <span class="text-xs text-rose-700" *ngIf="infoError">{{ infoError }}</span>
+                <span class="text-xs text-emerald-700 dark:text-emerald-300" *ngIf="infoMessage">{{ infoMessage }}</span>
+                <span class="text-xs text-rose-700 dark:text-rose-300" *ngIf="infoError">{{ infoError }}</span>
               </div>
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">Homepage hero (per language)</h2>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">Homepage hero (per language)</h2>
               <div class="flex gap-2 text-sm">
                 <button
                   class="px-3 py-1 rounded border"
@@ -201,70 +201,70 @@ import { firstValueFrom } from 'rxjs';
             </div>
             <div class="flex gap-2">
               <app-button label="Save hero" (action)="saveHero()"></app-button>
-              <span class="text-xs text-emerald-700" *ngIf="heroMessage()">{{ heroMessage() }}</span>
-              <span class="text-xs text-rose-700" *ngIf="heroError()">{{ heroError() }}</span>
+              <span class="text-xs text-emerald-700 dark:text-emerald-300" *ngIf="heroMessage()">{{ heroMessage() }}</span>
+              <span class="text-xs text-rose-700 dark:text-rose-300" *ngIf="heroError()">{{ heroError() }}</span>
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">Homepage sections order</h2>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">Homepage sections order</h2>
               <app-button size="sm" variant="ghost" label="Save order" (action)="saveSections()"></app-button>
             </div>
-            <p class="text-sm text-slate-600">Drag to reorder hero / collections / bestsellers / new arrivals.</p>
+            <p class="text-sm text-slate-600 dark:text-slate-300">Drag to reorder hero / collections / bestsellers / new arrivals.</p>
             <div class="grid gap-2">
               <div
                 *ngFor="let section of sectionOrder"
-                class="flex items-center justify-between rounded-lg border border-dashed border-slate-300 p-3 text-sm bg-slate-50"
+                class="flex items-center justify-between rounded-lg border border-dashed border-slate-300 p-3 text-sm bg-slate-50 dark:border-slate-700 dark:bg-slate-950/30"
                 draggable="true"
                 (dragstart)="onSectionDragStart(section)"
                 (dragover)="onSectionDragOver($event)"
                 (drop)="onSectionDrop(section)"
               >
-                <span class="font-semibold text-slate-900 capitalize">{{ section.replace('_', ' ') }}</span>
-                <span class="text-xs text-slate-500">drag</span>
+                <span class="font-semibold text-slate-900 dark:text-slate-50 capitalize">{{ section.replace('_', ' ') }}</span>
+                <span class="text-xs text-slate-500 dark:text-slate-400">drag</span>
               </div>
             </div>
-            <span class="text-xs text-emerald-700" *ngIf="sectionsMessage">{{ sectionsMessage }}</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300" *ngIf="sectionsMessage">{{ sectionsMessage }}</span>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">Featured collections</h2>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">Featured collections</h2>
               <app-button size="sm" variant="ghost" label="Reset" (action)="resetCollectionForm()"></app-button>
             </div>
             <div class="grid md:grid-cols-2 gap-3 text-sm">
               <app-input label="Slug" [(value)]="collectionForm.slug"></app-input>
               <app-input label="Name" [(value)]="collectionForm.name"></app-input>
-              <label class="grid text-sm font-medium text-slate-700 md:col-span-2">
+              <label class="grid text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
                 Description
-                <textarea class="rounded-lg border border-slate-200 px-3 py-2" rows="2" [(ngModel)]="collectionForm.description"></textarea>
+                <textarea class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" rows="2" [(ngModel)]="collectionForm.description"></textarea>
               </label>
-              <label class="grid text-sm font-medium text-slate-700 md:col-span-2">
+              <label class="grid text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
                 Products (hold Ctrl/Cmd to multi-select)
-                <select multiple class="rounded-lg border border-slate-200 px-3 py-2 min-h-[120px]" [(ngModel)]="collectionForm.product_ids">
+                <select multiple class="rounded-lg border border-slate-200 bg-white px-3 py-2 min-h-[120px] text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [(ngModel)]="collectionForm.product_ids">
                   <option *ngFor="let p of products" [value]="p.id">{{ p.name }} ({{ p.slug }})</option>
                 </select>
               </label>
             </div>
             <div class="flex gap-2">
               <app-button [label]="editingCollection ? 'Update collection' : 'Create collection'" (action)="saveCollection()"></app-button>
-              <span class="text-xs text-emerald-700" *ngIf="collectionMessage">{{ collectionMessage }}</span>
+              <span class="text-xs text-emerald-700 dark:text-emerald-300" *ngIf="collectionMessage">{{ collectionMessage }}</span>
             </div>
-            <div class="grid gap-2 text-sm text-slate-700">
-              <div *ngFor="let col of featuredCollections" class="rounded-lg border border-slate-200 p-3 flex items-center justify-between">
+            <div class="grid gap-2 text-sm text-slate-700 dark:text-slate-200">
+              <div *ngFor="let col of featuredCollections" class="rounded-lg border border-slate-200 p-3 flex items-center justify-between dark:border-slate-700">
                 <div>
-                  <p class="font-semibold text-slate-900">{{ col.name }}</p>
-                  <p class="text-xs text-slate-500">{{ col.slug }} · {{ col.description }}</p>
+                  <p class="font-semibold text-slate-900 dark:text-slate-50">{{ col.name }}</p>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">{{ col.slug }} · {{ col.description }}</p>
                 </div>
                 <app-button size="sm" variant="ghost" label="Edit" (action)="editCollection(col)"></app-button>
               </div>
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">{{ 'adminUi.products.title' | translate }}</h2>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'adminUi.products.title' | translate }}</h2>
               <div class="flex gap-2">
                 <app-button size="sm" [label]="'adminUi.products.new' | translate" (action)="startNewProduct()"></app-button>
                 <app-button
@@ -283,7 +283,7 @@ import { firstValueFrom } from 'rxjs';
             <div class="overflow-auto">
               <table class="min-w-full text-sm text-left">
                 <thead>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-slate-800">
                     <th class="py-2">
                       <input type="checkbox" [checked]="allSelected" (change)="toggleAll($event)" />
                     </th>
@@ -297,7 +297,7 @@ import { firstValueFrom } from 'rxjs';
                   </tr>
                 </thead>
                 <tbody>
-                  <tr *ngFor="let product of products" class="border-b border-slate-100">
+                  <tr *ngFor="let product of products" class="border-b border-slate-100 dark:border-slate-800">
                     <td class="py-2">
                       <input
                         type="checkbox"
@@ -305,17 +305,17 @@ import { firstValueFrom } from 'rxjs';
                         (change)="toggleSelect(product.id, $event)"
                       />
                     </td>
-                    <td class="py-2 font-semibold text-slate-900">
+                    <td class="py-2 font-semibold text-slate-900 dark:text-slate-50">
                       {{ product.name }}
                       <span *ngIf="product.tags?.includes('bestseller')" class="ml-2 text-[10px] uppercase bg-amber-100 text-amber-800 px-2 py-0.5 rounded-full">Bestseller</span>
                       <span *ngIf="product.tags?.includes('highlight')" class="ml-1 text-[10px] uppercase bg-indigo-100 text-indigo-800 px-2 py-0.5 rounded-full">Highlight</span>
                     </td>
                     <td>{{ product.price | localizedCurrency : product.currency || 'USD' }}</td>
-                    <td><span class="text-xs rounded-full bg-slate-100 px-2 py-1">{{ product.status }}</span></td>
+                    <td><span class="text-xs rounded-full bg-slate-100 px-2 py-1 dark:bg-slate-800">{{ product.status }}</span></td>
                     <td>{{ product.category }}</td>
                     <td class="flex items-center gap-2">
                       <input
-                        class="w-20 rounded border border-slate-200 px-2 py-1"
+                        class="w-20 rounded border border-slate-200 bg-white px-2 py-1 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
                         type="number"
                         [ngModel]="stockEdits[product.id] ?? product.stock_quantity"
                         (ngModelChange)="setStock(product.id, $event)"
@@ -323,8 +323,8 @@ import { firstValueFrom } from 'rxjs';
                       <app-button size="xs" variant="ghost" label="Save" (action)="saveStock(product)"></app-button>
                     </td>
                     <td>
-                      <span *ngIf="product.publish_at" class="text-xs text-slate-600">{{ product.publish_at | date: 'short' }}</span>
-                      <span *ngIf="!product.publish_at" class="text-xs text-slate-400">—</span>
+                      <span *ngIf="product.publish_at" class="text-xs text-slate-600 dark:text-slate-300">{{ product.publish_at | date: 'short' }}</span>
+                      <span *ngIf="!product.publish_at" class="text-xs text-slate-400 dark:text-slate-500">—</span>
                     </td>
                     <td class="flex gap-2 py-2">
                       <app-button size="sm" variant="ghost" [label]="'adminUi.products.actions.update' | translate" (action)="loadProduct(product.slug)"></app-button>
@@ -334,18 +334,18 @@ import { firstValueFrom } from 'rxjs';
                 </tbody>
               </table>
             </div>
-            <div *ngIf="upcomingProducts().length" class="rounded-lg border border-slate-200 p-3 text-sm text-slate-700">
-              <p class="font-semibold text-slate-900 mb-2">Upcoming scheduled products</p>
-              <div *ngFor="let p of upcomingProducts()" class="flex items-center justify-between py-1 border-b border-slate-100 last:border-0">
+            <div *ngIf="upcomingProducts().length" class="rounded-lg border border-slate-200 p-3 text-sm text-slate-700 dark:border-slate-700 dark:text-slate-200">
+              <p class="font-semibold text-slate-900 dark:text-slate-50 mb-2">Upcoming scheduled products</p>
+              <div *ngFor="let p of upcomingProducts()" class="flex items-center justify-between py-1 border-b border-slate-100 dark:border-slate-800 last:border-0">
                 <span>{{ p.name }}</span>
-                <span class="text-xs text-slate-600">Publishes {{ p.publish_at | date: 'medium' }}</span>
+                <span class="text-xs text-slate-600 dark:text-slate-300">Publishes {{ p.publish_at | date: 'medium' }}</span>
               </div>
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">
                 {{ editingId ? ('adminUi.products.edit' | translate) : ('adminUi.products.create' | translate) }}
               </h2>
               <app-button size="sm" variant="ghost" [label]="'adminUi.actions.reset' | translate" (action)="startNewProduct()"></app-button>
@@ -353,21 +353,21 @@ import { firstValueFrom } from 'rxjs';
             <div class="grid md:grid-cols-2 gap-3 text-sm">
               <app-input [label]="'adminUi.products.table.name' | translate" [(value)]="form.name"></app-input>
               <app-input [label]="'adminUi.products.form.slug' | translate" [(value)]="form.slug"></app-input>
-              <label class="grid text-sm font-medium text-slate-700">
+              <label class="grid text-sm font-medium text-slate-700 dark:text-slate-200">
                 {{ 'adminUi.products.table.category' | translate }}
-                <select class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="form.category_id">
+                <select class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [(ngModel)]="form.category_id">
                   <option *ngFor="let c of categories" [value]="c.id">{{ c.name }}</option>
                 </select>
               </label>
               <app-input [label]="'adminUi.products.table.price' | translate" type="number" [(value)]="form.price"></app-input>
               <app-input [label]="'adminUi.products.table.stock' | translate" type="number" [(value)]="form.stock"></app-input>
-              <label class="grid text-sm font-medium text-slate-700">
+              <label class="grid text-sm font-medium text-slate-700 dark:text-slate-200">
                 Publish at (optional)
-                <input class="rounded-lg border border-slate-200 px-3 py-2" type="datetime-local" [(ngModel)]="form.publish_at" />
+                <input class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" type="datetime-local" [(ngModel)]="form.publish_at" />
               </label>
-              <label class="grid text-sm font-medium text-slate-700">
+              <label class="grid text-sm font-medium text-slate-700 dark:text-slate-200">
                 {{ 'adminUi.products.table.status' | translate }}
-                <select class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="form.status">
+                <select class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [(ngModel)]="form.status">
                   <option value="draft">{{ 'adminUi.status.draft' | translate }}</option>
                   <option value="published">{{ 'adminUi.status.published' | translate }}</option>
                   <option value="archived">{{ 'adminUi.status.archived' | translate }}</option>
@@ -384,51 +384,51 @@ import { firstValueFrom } from 'rxjs';
                 <input type="checkbox" [(ngModel)]="form.is_highlight" /> Highlight badge
               </label>
             </div>
-            <label class="grid gap-1 text-sm font-medium text-slate-700">
+            <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
               {{ 'adminUi.products.form.description' | translate }}
-              <textarea rows="3" class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="form.description"></textarea>
+              <textarea rows="3" class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [(ngModel)]="form.description"></textarea>
             </label>
             <div class="flex gap-3">
               <app-button [label]="'adminUi.products.form.save' | translate" (action)="saveProduct()"></app-button>
-              <label class="text-sm text-indigo-600 font-medium cursor-pointer">
+              <label class="text-sm text-indigo-600 dark:text-indigo-300 font-medium cursor-pointer">
                 {{ 'adminUi.products.form.upload' | translate }}
                 <input type="file" class="hidden" accept="image/*" (change)="onImageUpload($event)" />
               </label>
             </div>
             <div class="grid gap-2" *ngIf="productImages().length">
-              <p class="text-xs uppercase tracking-[0.2em] text-slate-500">{{ 'adminUi.products.form.images' | translate }}</p>
-              <div *ngFor="let img of productImages()" class="flex items-center gap-3 rounded-lg border border-slate-200 p-2">
+              <p class="text-xs uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">{{ 'adminUi.products.form.images' | translate }}</p>
+              <div *ngFor="let img of productImages()" class="flex items-center gap-3 rounded-lg border border-slate-200 p-2 dark:border-slate-700">
                 <img [src]="img.url" [alt]="img.alt_text || 'image'" class="h-12 w-12 rounded object-cover" />
                 <div class="flex-1">
-                  <p class="font-semibold text-slate-900">{{ img.alt_text || ('adminUi.products.form.image' | translate) }}</p>
+                  <p class="font-semibold text-slate-900 dark:text-slate-50">{{ img.alt_text || ('adminUi.products.form.image' | translate) }}</p>
                 </div>
                 <app-button size="sm" variant="ghost" [label]="'adminUi.actions.delete' | translate" (action)="deleteImage(img.id)"></app-button>
               </div>
             </div>
-            <p *ngIf="formMessage" class="text-sm text-emerald-700">{{ formMessage }}</p>
+            <p *ngIf="formMessage" class="text-sm text-emerald-700 dark:text-emerald-300">{{ formMessage }}</p>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">{{ 'adminUi.categories.title' | translate }}</h2>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'adminUi.categories.title' | translate }}</h2>
             </div>
             <div class="grid md:grid-cols-3 gap-2 items-end text-sm">
               <app-input [label]="'adminUi.products.table.name' | translate" [(value)]="categoryName"></app-input>
               <app-input [label]="'adminUi.categories.slug' | translate" [(value)]="categorySlug"></app-input>
               <app-button size="sm" [label]="'adminUi.categories.add' | translate" (action)="addCategory()"></app-button>
             </div>
-            <div class="grid gap-2 text-sm text-slate-700">
+            <div class="grid gap-2 text-sm text-slate-700 dark:text-slate-200">
               <div
                 *ngFor="let cat of categories"
-                class="flex items-center justify-between rounded-lg border border-slate-200 p-3"
+                class="flex items-center justify-between rounded-lg border border-slate-200 p-3 dark:border-slate-700"
                 draggable="true"
                 (dragstart)="onCategoryDragStart(cat.slug)"
                 (dragover)="onCategoryDragOver($event)"
                 (drop)="onCategoryDrop(cat.slug)"
               >
                 <div>
-                  <p class="font-semibold text-slate-900">{{ cat.name }}</p>
-                  <p class="text-xs text-slate-500">Slug: {{ cat.slug }} · Order: {{ cat.sort_order }}</p>
+                  <p class="font-semibold text-slate-900 dark:text-slate-50">{{ cat.name }}</p>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">Slug: {{ cat.slug }} · Order: {{ cat.sort_order }}</p>
                 </div>
                 <div class="flex gap-2">
                   <app-button size="sm" variant="ghost" label="↑" (action)="moveCategory(cat, -1)"></app-button>
@@ -439,12 +439,12 @@ import { firstValueFrom } from 'rxjs';
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">{{ 'adminUi.orders.title' | translate }}</h2>
-              <label class="text-sm text-slate-700">
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'adminUi.orders.title' | translate }}</h2>
+              <label class="text-sm text-slate-700 dark:text-slate-200">
                 {{ 'adminUi.orders.statusFilter' | translate }}
-                <select class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="orderFilter">
+                <select class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [(ngModel)]="orderFilter">
                   <option value="">{{ 'adminUi.orders.all' | translate }}</option>
                   <option value="pending">{{ 'adminUi.orders.pending' | translate }}</option>
                   <option value="paid">{{ 'adminUi.orders.paid' | translate }}</option>
@@ -454,19 +454,19 @@ import { firstValueFrom } from 'rxjs';
               </label>
             </div>
             <div class="grid md:grid-cols-[1.5fr_1fr] gap-4">
-              <div class="grid gap-2 text-sm text-slate-700">
-                <div *ngFor="let order of filteredOrders()" class="rounded-lg border border-slate-200 p-3 cursor-pointer" (click)="selectOrder(order)">
+              <div class="grid gap-2 text-sm text-slate-700 dark:text-slate-200">
+                <div *ngFor="let order of filteredOrders()" class="rounded-lg border border-slate-200 p-3 cursor-pointer dark:border-slate-700" (click)="selectOrder(order)">
                   <div class="flex items-center justify-between">
-                    <span class="font-semibold text-slate-900">Order #{{ order.id }}</span>
-                    <span class="text-xs rounded-full bg-slate-100 px-2 py-1">{{ order.status }}</span>
+                    <span class="font-semibold text-slate-900 dark:text-slate-50">Order #{{ order.id }}</span>
+                    <span class="text-xs rounded-full bg-slate-100 px-2 py-1 dark:bg-slate-800">{{ order.status }}</span>
                   </div>
                   <p>{{ order.customer }} — {{ order.total_amount | localizedCurrency : order.currency || 'USD' }}</p>
                 </div>
               </div>
-              <div class="rounded-lg border border-slate-200 p-4 text-sm text-slate-700" *ngIf="activeOrder">
+              <div class="rounded-lg border border-slate-200 p-4 text-sm text-slate-700 dark:border-slate-700 dark:text-slate-200" *ngIf="activeOrder">
                 <div class="flex items-center justify-between">
-                  <h3 class="font-semibold text-slate-900">Order #{{ activeOrder.id }}</h3>
-                  <select class="rounded-lg border border-slate-200 px-2 py-1 text-sm" [ngModel]="activeOrder.status" (ngModelChange)="changeOrderStatus($event)">
+                  <h3 class="font-semibold text-slate-900 dark:text-slate-50">Order #{{ activeOrder.id }}</h3>
+                  <select class="rounded-lg border border-slate-200 bg-white px-2 py-1 text-sm text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [ngModel]="activeOrder.status" (ngModelChange)="changeOrderStatus($event)">
                     <option value="pending">{{ 'adminUi.orders.pending' | translate }}</option>
                     <option value="paid">{{ 'adminUi.orders.paid' | translate }}</option>
                     <option value="shipped">{{ 'adminUi.orders.shipped' | translate }}</option>
@@ -474,16 +474,16 @@ import { firstValueFrom } from 'rxjs';
                     <option value="refunded">{{ 'adminUi.orders.refunded' | translate }}</option>
                   </select>
                 </div>
-                <p class="text-xs text-slate-500">Customer: {{ activeOrder.customer }}</p>
-                <p class="text-xs text-slate-500">Placed: {{ activeOrder.created_at | date: 'medium' }}</p>
-                <p class="font-semibold text-slate-900 mt-2">{{ activeOrder.total_amount | localizedCurrency : activeOrder.currency || 'USD' }}</p>
+                <p class="text-xs text-slate-500 dark:text-slate-400">Customer: {{ activeOrder.customer }}</p>
+                <p class="text-xs text-slate-500 dark:text-slate-400">Placed: {{ activeOrder.created_at | date: 'medium' }}</p>
+                <p class="font-semibold text-slate-900 dark:text-slate-50 mt-2">{{ activeOrder.total_amount | localizedCurrency : activeOrder.currency || 'USD' }}</p>
               </div>
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">{{ 'adminUi.users.title' | translate }}</h2>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'adminUi.users.title' | translate }}</h2>
               <div class="flex gap-2">
                 <app-button
                   size="sm"
@@ -501,15 +501,15 @@ import { firstValueFrom } from 'rxjs';
                 ></app-button>
               </div>
             </div>
-            <div class="grid gap-2 text-sm text-slate-700">
-              <div *ngFor="let user of users" class="flex items-center justify-between rounded-lg border border-slate-200 p-3">
+            <div class="grid gap-2 text-sm text-slate-700 dark:text-slate-200">
+              <div *ngFor="let user of users" class="flex items-center justify-between rounded-lg border border-slate-200 p-3 dark:border-slate-700">
                 <div>
-                  <p class="font-semibold text-slate-900">{{ user.name || user.email }}</p>
-                  <p class="text-xs text-slate-500">{{ user.email }}</p>
+                  <p class="font-semibold text-slate-900 dark:text-slate-50">{{ user.name || user.email }}</p>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">{{ user.email }}</p>
                 </div>
                 <div class="flex items-center gap-2 text-xs">
                   <input type="radio" name="userSelect" [value]="user.id" [(ngModel)]="selectedUserId" />
-                  <select class="rounded border border-slate-200 px-2 py-1" [ngModel]="user.role" (ngModelChange)="selectUser(user.id, $event)">
+                  <select class="rounded border border-slate-200 bg-white px-2 py-1 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [ngModel]="user.role" (ngModelChange)="selectUser(user.id, $event)">
                     <option value="customer">{{ 'adminUi.users.roles.customer' | translate }}</option>
                     <option value="admin">{{ 'adminUi.users.roles.admin' | translate }}</option>
                   </select>
@@ -518,60 +518,60 @@ import { firstValueFrom } from 'rxjs';
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">{{ 'adminUi.content.title' | translate }}</h2>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'adminUi.content.title' | translate }}</h2>
             </div>
-            <div class="grid gap-2 text-sm text-slate-700">
-              <div *ngFor="let c of contentBlocks" class="flex items-center justify-between rounded-lg border border-slate-200 p-3">
+            <div class="grid gap-2 text-sm text-slate-700 dark:text-slate-200">
+              <div *ngFor="let c of contentBlocks" class="flex items-center justify-between rounded-lg border border-slate-200 p-3 dark:border-slate-700">
                 <div>
-                  <p class="font-semibold text-slate-900">{{ c.title }}</p>
-                  <p class="text-xs text-slate-500">{{ c.key }} · v{{ c.version }} · {{ c.updated_at | date: 'short' }}</p>
+                  <p class="font-semibold text-slate-900 dark:text-slate-50">{{ c.title }}</p>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">{{ c.key }} · v{{ c.version }} · {{ c.updated_at | date: 'short' }}</p>
                 </div>
                 <app-button size="sm" variant="ghost" [label]="'adminUi.actions.edit' | translate" (action)="selectContent(c)"></app-button>
               </div>
             </div>
-            <div *ngIf="selectedContent" class="grid gap-2 pt-3 border-t border-slate-200">
-              <p class="text-sm font-semibold text-slate-900">{{ 'adminUi.content.editing' | translate }}: {{ selectedContent.key }}</p>
+            <div *ngIf="selectedContent" class="grid gap-2 pt-3 border-t border-slate-200 dark:border-slate-800">
+              <p class="text-sm font-semibold text-slate-900 dark:text-slate-50">{{ 'adminUi.content.editing' | translate }}: {{ selectedContent.key }}</p>
               <app-input [label]="'adminUi.content.titleLabel' | translate" [(value)]="contentForm.title"></app-input>
-              <label class="grid text-sm font-medium text-slate-700">
+              <label class="grid text-sm font-medium text-slate-700 dark:text-slate-200">
                 {{ 'adminUi.content.status' | translate }}
-                <select class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="contentForm.status">
+                <select class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [(ngModel)]="contentForm.status">
                   <option value="draft">{{ 'adminUi.status.draft' | translate }}</option>
                   <option value="published">{{ 'adminUi.status.published' | translate }}</option>
                 </select>
               </label>
-              <label class="grid gap-1 text-sm font-medium text-slate-700">
+              <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
                 {{ 'adminUi.content.body' | translate }}
-                <textarea rows="4" class="rounded-lg border border-slate-200 px-3 py-2" [(ngModel)]="contentForm.body_markdown"></textarea>
+                <textarea rows="4" class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" [(ngModel)]="contentForm.body_markdown"></textarea>
               </label>
               <div class="flex gap-2">
                 <app-button size="sm" [label]="'adminUi.content.save' | translate" (action)="saveContent()"></app-button>
                 <app-button size="sm" variant="ghost" [label]="'adminUi.actions.cancel' | translate" (action)="cancelContent()"></app-button>
-                <label class="flex items-center gap-2 text-xs text-slate-600">
+                <label class="flex items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
                   <input type="checkbox" [(ngModel)]="showContentPreview" /> Live preview
                 </label>
               </div>
-              <div *ngIf="showContentPreview" class="rounded-lg border border-slate-200 p-3 bg-slate-50 text-sm text-slate-800 whitespace-pre-line">
+              <div *ngIf="showContentPreview" class="rounded-lg border border-slate-200 p-3 bg-slate-50 text-sm text-slate-800 whitespace-pre-line dark:border-slate-700 dark:bg-slate-950/30 dark:text-slate-200">
                 {{ contentForm.body_markdown || 'Nothing to preview yet.' }}
               </div>
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">{{ 'adminUi.coupons.title' | translate }}</h2>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'adminUi.coupons.title' | translate }}</h2>
             </div>
-            <div class="grid gap-2 text-sm text-slate-700">
+            <div class="grid gap-2 text-sm text-slate-700 dark:text-slate-200">
               <div class="grid md:grid-cols-3 gap-2 items-end">
                 <app-input [label]="'adminUi.coupons.code' | translate" [(value)]="newCoupon.code"></app-input>
                 <app-input [label]="'adminUi.coupons.percentOff' | translate" type="number" [(value)]="newCoupon.percentage_off"></app-input>
                 <app-button size="sm" [label]="'adminUi.coupons.add' | translate" (action)="createCoupon()"></app-button>
               </div>
-              <div *ngFor="let coupon of coupons" class="flex items-center justify-between rounded-lg border border-slate-200 p-3">
+              <div *ngFor="let coupon of coupons" class="flex items-center justify-between rounded-lg border border-slate-200 p-3 dark:border-slate-700">
                 <div>
-                  <p class="font-semibold text-slate-900">{{ coupon.code }}</p>
-                  <p class="text-xs text-slate-500">
+                  <p class="font-semibold text-slate-900 dark:text-slate-50">{{ coupon.code }}</p>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">
                     <ng-container *ngIf="coupon.percentage_off">-{{ coupon.percentage_off }}%</ng-container>
                     <ng-container *ngIf="coupon.amount_off">-{{ coupon.amount_off | localizedCurrency : coupon.currency || 'USD' }}</ng-container>
                     <ng-container *ngIf="!coupon.percentage_off && !coupon.amount_off">{{ 'adminUi.coupons.none' | translate }}</ng-container>
@@ -579,7 +579,7 @@ import { firstValueFrom } from 'rxjs';
                 </div>
                 <button
                   type="button"
-                  class="text-xs rounded-full px-2 py-1 border"
+                  class="text-xs rounded-full px-2 py-1 border border-slate-200 dark:border-slate-700"
                   [class.bg-emerald-100]="coupon.active"
                   [class.text-emerald-800]="coupon.active"
                   (click)="toggleCoupon(coupon)"
@@ -590,56 +590,56 @@ import { firstValueFrom } from 'rxjs';
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">{{ 'adminUi.audit.title' | translate }}</h2>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'adminUi.audit.title' | translate }}</h2>
               <app-button size="sm" variant="ghost" [label]="'adminUi.actions.refresh' | translate" (action)="loadAudit()"></app-button>
             </div>
-            <div class="grid md:grid-cols-2 gap-4 text-sm text-slate-700">
+            <div class="grid md:grid-cols-2 gap-4 text-sm text-slate-700 dark:text-slate-200">
               <div class="grid gap-2">
-                <p class="text-xs uppercase tracking-[0.2em] text-slate-500">{{ 'adminUi.audit.products' | translate }}</p>
-                <div *ngFor="let log of productAudit" class="rounded-lg border border-slate-200 p-3">
-                  <p class="font-semibold text-slate-900">{{ log.action }}</p>
-                  <p class="text-xs text-slate-500">{{ 'adminUi.audit.productId' | translate }} {{ log.product_id }}</p>
-                  <p class="text-xs text-slate-500">{{ 'adminUi.audit.at' | translate }} {{ log.created_at | date: 'short' }}</p>
+                <p class="text-xs uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">{{ 'adminUi.audit.products' | translate }}</p>
+                <div *ngFor="let log of productAudit" class="rounded-lg border border-slate-200 p-3 dark:border-slate-700">
+                  <p class="font-semibold text-slate-900 dark:text-slate-50">{{ log.action }}</p>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">{{ 'adminUi.audit.productId' | translate }} {{ log.product_id }}</p>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">{{ 'adminUi.audit.at' | translate }} {{ log.created_at | date: 'short' }}</p>
                 </div>
               </div>
               <div class="grid gap-2">
-                <p class="text-xs uppercase tracking-[0.2em] text-slate-500">{{ 'adminUi.audit.content' | translate }}</p>
-                <div *ngFor="let log of contentAudit" class="rounded-lg border border-slate-200 p-3">
-                  <p class="font-semibold text-slate-900">{{ log.action }}</p>
-                  <p class="text-xs text-slate-500">{{ 'adminUi.audit.blockId' | translate }} {{ log.block_id }}</p>
-                  <p class="text-xs text-slate-500">{{ 'adminUi.audit.at' | translate }} {{ log.created_at | date: 'short' }}</p>
+                <p class="text-xs uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">{{ 'adminUi.audit.content' | translate }}</p>
+                <div *ngFor="let log of contentAudit" class="rounded-lg border border-slate-200 p-3 dark:border-slate-700">
+                  <p class="font-semibold text-slate-900 dark:text-slate-50">{{ log.action }}</p>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">{{ 'adminUi.audit.blockId' | translate }} {{ log.block_id }}</p>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">{{ 'adminUi.audit.at' | translate }} {{ log.created_at | date: 'short' }}</p>
                 </div>
               </div>
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">{{ 'adminUi.maintenance.title' | translate }}</h2>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'adminUi.maintenance.title' | translate }}</h2>
               <app-button size="sm" [label]="'adminUi.actions.save' | translate" (action)="saveMaintenance()"></app-button>
             </div>
             <div class="flex items-center gap-3 text-sm">
               <label class="flex items-center gap-2">
                 <input type="checkbox" [(ngModel)]="maintenanceEnabledValue" /> {{ 'adminUi.maintenance.mode' | translate }}
               </label>
-              <a class="text-indigo-600" href="/api/v1/sitemap.xml" target="_blank" rel="noopener">{{ 'adminUi.maintenance.sitemap' | translate }}</a>
-              <a class="text-indigo-600" href="/api/v1/robots.txt" target="_blank" rel="noopener">{{ 'adminUi.maintenance.robots' | translate }}</a>
-              <a class="text-indigo-600" href="/api/v1/feeds/products.json" target="_blank" rel="noopener">{{ 'adminUi.maintenance.feed' | translate }}</a>
+              <a class="text-indigo-600 dark:text-indigo-300" href="/api/v1/sitemap.xml" target="_blank" rel="noopener">{{ 'adminUi.maintenance.sitemap' | translate }}</a>
+              <a class="text-indigo-600 dark:text-indigo-300" href="/api/v1/robots.txt" target="_blank" rel="noopener">{{ 'adminUi.maintenance.robots' | translate }}</a>
+              <a class="text-indigo-600 dark:text-indigo-300" href="/api/v1/feeds/products.json" target="_blank" rel="noopener">{{ 'adminUi.maintenance.feed' | translate }}</a>
             </div>
           </section>
 
-          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <section class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">{{ 'adminUi.lowStock.title' | translate }}</h2>
-              <span class="text-xs text-slate-500">{{ 'adminUi.lowStock.hint' | translate }}</span>
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'adminUi.lowStock.title' | translate }}</h2>
+              <span class="text-xs text-slate-500 dark:text-slate-400">{{ 'adminUi.lowStock.hint' | translate }}</span>
             </div>
-            <div class="grid gap-2 text-sm text-slate-700">
-              <div *ngFor="let item of lowStock" class="flex items-center justify-between rounded-lg border border-slate-200 p-3">
+            <div class="grid gap-2 text-sm text-slate-700 dark:text-slate-200">
+              <div *ngFor="let item of lowStock" class="flex items-center justify-between rounded-lg border border-slate-200 p-3 dark:border-slate-700">
                 <div>
-                  <p class="font-semibold text-slate-900">{{ item.name }}</p>
-                  <p class="text-xs text-slate-500">{{ item.sku }} — {{ item.slug }}</p>
+                  <p class="font-semibold text-slate-900 dark:text-slate-50">{{ item.name }}</p>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">{{ item.sku }} — {{ item.slug }}</p>
                 </div>
                 <span class="text-xs rounded-full bg-amber-100 px-2 py-1 text-amber-900">{{ 'adminUi.lowStock.stock' | translate:{count: item.stock_quantity} }}</span>
               </div>
@@ -647,7 +647,7 @@ import { firstValueFrom } from 'rxjs';
           </section>
         </div>
         <ng-template #loadingTpl>
-          <div class="rounded-2xl border border-slate-200 bg-white p-4">
+          <div class="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <app-skeleton [rows]="6"></app-skeleton>
           </div>
         </ng-template>

--- a/frontend/src/app/pages/auth/google-callback.component.ts
+++ b/frontend/src/app/pages/auth/google-callback.component.ts
@@ -10,11 +10,11 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
   standalone: true,
   imports: [CommonModule, TranslateModule],
   template: `
-    <div class="min-h-screen flex items-center justify-center bg-slate-50 px-4">
-      <div class="bg-white border border-slate-200 rounded-xl shadow-sm p-6 w-full max-w-md grid gap-3 text-center">
-        <p class="text-lg font-semibold text-slate-900">{{ 'auth.googleFinishing' | translate }}</p>
-        <p class="text-sm text-slate-600" *ngIf="message()">{{ message() }}</p>
-        <p class="text-sm text-rose-700" *ngIf="error()">{{ error() }}</p>
+    <div class="min-h-screen flex items-center justify-center bg-slate-50 px-4 dark:bg-slate-950">
+      <div class="bg-white border border-slate-200 rounded-xl shadow-sm p-6 w-full max-w-md grid gap-3 text-center dark:bg-slate-900 dark:border-slate-700 dark:shadow-none">
+        <p class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'auth.googleFinishing' | translate }}</p>
+        <p class="text-sm text-slate-600 dark:text-slate-300" *ngIf="message()">{{ message() }}</p>
+        <p class="text-sm text-rose-700 dark:text-rose-300" *ngIf="error()">{{ error() }}</p>
       </div>
     </div>
   `

--- a/frontend/src/app/pages/auth/login.component.ts
+++ b/frontend/src/app/pages/auth/login.component.ts
@@ -16,36 +16,36 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
   template: `
     <app-container classes="py-10 grid gap-6 max-w-xl">
       <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
-      <h1 class="text-2xl font-semibold text-slate-900">{{ 'auth.loginTitle' | translate }}</h1>
+      <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-50">{{ 'auth.loginTitle' | translate }}</h1>
       <form #loginForm="ngForm" class="grid gap-4" (ngSubmit)="onSubmit(loginForm)">
-        <label class="grid gap-1 text-sm font-medium text-slate-700">
+        <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           {{ 'auth.email' | translate }}
           <input
             name="email"
             type="email"
-            class="rounded-lg border border-slate-200 px-3 py-2"
+            class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
             required
             [(ngModel)]="email"
           />
         </label>
-        <label class="grid gap-1 text-sm font-medium text-slate-700">
+        <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           {{ 'auth.password' | translate }}
           <input
             name="password"
             type="password"
-            class="rounded-lg border border-slate-200 px-3 py-2"
+            class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
             required
             minlength="6"
             [(ngModel)]="password"
           />
         </label>
         <div class="flex items-center justify-between text-sm">
-          <a routerLink="/password-reset" class="text-indigo-600 font-medium">{{ 'auth.forgot' | translate }}</a>
-          <a routerLink="/register" class="text-slate-600 hover:text-slate-900">{{ 'auth.createAccount' | translate }}</a>
+          <a routerLink="/password-reset" class="text-indigo-600 dark:text-indigo-300 font-medium">{{ 'auth.forgot' | translate }}</a>
+          <a routerLink="/register" class="text-slate-600 hover:text-slate-900 dark:text-slate-300 dark:hover:text-slate-50">{{ 'auth.createAccount' | translate }}</a>
         </div>
         <app-button [label]="'auth.login' | translate" type="submit"></app-button>
-        <div class="border-t border-slate-200 pt-4 grid gap-2">
-          <p class="text-sm text-slate-600 text-center">{{ 'auth.orContinue' | translate }}</p>
+        <div class="border-t border-slate-200 pt-4 grid gap-2 dark:border-slate-800">
+          <p class="text-sm text-slate-600 dark:text-slate-300 text-center">{{ 'auth.orContinue' | translate }}</p>
           <app-button variant="ghost" [label]="'auth.googleContinue' | translate" (action)="startGoogle()"></app-button>
         </div>
       </form>

--- a/frontend/src/app/pages/auth/password-reset-request.component.ts
+++ b/frontend/src/app/pages/auth/password-reset-request.component.ts
@@ -16,15 +16,15 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
   template: `
     <app-container classes="py-10 grid gap-6 max-w-xl">
       <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
-      <h1 class="text-2xl font-semibold text-slate-900">{{ 'auth.resetRequestTitle' | translate }}</h1>
-      <p class="text-sm text-slate-600">{{ 'auth.resetRequestCopy' | translate }}</p>
+      <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-50">{{ 'auth.resetRequestTitle' | translate }}</h1>
+      <p class="text-sm text-slate-600 dark:text-slate-300">{{ 'auth.resetRequestCopy' | translate }}</p>
       <form #resetForm="ngForm" class="grid gap-4" (ngSubmit)="onSubmit(resetForm)">
-        <label class="grid gap-1 text-sm font-medium text-slate-700">
+        <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           {{ 'auth.email' | translate }}
-          <input name="email" type="email" class="rounded-lg border border-slate-200 px-3 py-2" required [(ngModel)]="email" />
+          <input name="email" type="email" class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400" required [(ngModel)]="email" />
         </label>
         <app-button [label]="'auth.resetLink' | translate" type="submit"></app-button>
-        <a routerLink="/login" class="text-sm text-indigo-600 font-medium">{{ 'auth.backToLogin' | translate }}</a>
+        <a routerLink="/login" class="text-sm text-indigo-600 dark:text-indigo-300 font-medium">{{ 'auth.backToLogin' | translate }}</a>
       </form>
     </app-container>
   `

--- a/frontend/src/app/pages/auth/password-reset.component.ts
+++ b/frontend/src/app/pages/auth/password-reset.component.ts
@@ -16,36 +16,36 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
   template: `
     <app-container classes="py-10 grid gap-6 max-w-xl">
       <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
-      <h1 class="text-2xl font-semibold text-slate-900">{{ 'auth.resetTitle' | translate }}</h1>
+      <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-50">{{ 'auth.resetTitle' | translate }}</h1>
       <form #resetForm="ngForm" class="grid gap-4" (ngSubmit)="onSubmit(resetForm)">
-        <label class="grid gap-1 text-sm font-medium text-slate-700">
+        <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           {{ 'auth.resetCode' | translate }}
-          <input name="token" class="rounded-lg border border-slate-200 px-3 py-2" required [(ngModel)]="token" />
+          <input name="token" class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400" required [(ngModel)]="token" />
         </label>
-        <label class="grid gap-1 text-sm font-medium text-slate-700">
+        <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           {{ 'auth.password' | translate }}
           <input
             name="password"
             type="password"
-            class="rounded-lg border border-slate-200 px-3 py-2"
+            class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
             required
             minlength="6"
             [(ngModel)]="password"
           />
         </label>
-        <label class="grid gap-1 text-sm font-medium text-slate-700">
+        <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           {{ 'auth.confirmPassword' | translate }}
           <input
             name="confirm"
             type="password"
-            class="rounded-lg border border-slate-200 px-3 py-2"
+            class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
             required
             [(ngModel)]="confirmPassword"
           />
         </label>
-        <p *ngIf="error" class="text-sm text-amber-700">{{ error }}</p>
+        <p *ngIf="error" class="text-sm text-amber-700 dark:text-amber-300">{{ error }}</p>
         <app-button [label]="'auth.setPassword' | translate" type="submit"></app-button>
-        <a routerLink="/login" class="text-sm text-indigo-600 font-medium">{{ 'auth.backToLogin' | translate }}</a>
+        <a routerLink="/login" class="text-sm text-indigo-600 dark:text-indigo-300 font-medium">{{ 'auth.backToLogin' | translate }}</a>
       </form>
     </app-container>
   `

--- a/frontend/src/app/pages/auth/register.component.ts
+++ b/frontend/src/app/pages/auth/register.component.ts
@@ -16,46 +16,46 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
   template: `
     <app-container classes="py-10 grid gap-6 max-w-xl">
       <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
-      <h1 class="text-2xl font-semibold text-slate-900">{{ 'auth.registerTitle' | translate }}</h1>
+      <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-50">{{ 'auth.registerTitle' | translate }}</h1>
       <form #registerForm="ngForm" class="grid gap-4" (ngSubmit)="onSubmit(registerForm)">
-        <label class="grid gap-1 text-sm font-medium text-slate-700">
+        <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           {{ 'auth.name' | translate }}
-          <input name="name" class="rounded-lg border border-slate-200 px-3 py-2" required [(ngModel)]="name" />
+          <input name="name" class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400" required [(ngModel)]="name" />
         </label>
-        <label class="grid gap-1 text-sm font-medium text-slate-700">
+        <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           {{ 'auth.email' | translate }}
-          <input name="email" type="email" class="rounded-lg border border-slate-200 px-3 py-2" required [(ngModel)]="email" />
+          <input name="email" type="email" class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400" required [(ngModel)]="email" />
         </label>
-        <label class="grid gap-1 text-sm font-medium text-slate-700">
+        <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           {{ 'auth.password' | translate }}
           <input
             name="password"
             type="password"
-            class="rounded-lg border border-slate-200 px-3 py-2"
+            class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
             required
             minlength="6"
             [(ngModel)]="password"
           />
         </label>
-        <label class="grid gap-1 text-sm font-medium text-slate-700">
+        <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           {{ 'auth.confirmPassword' | translate }}
           <input
             name="confirm"
             type="password"
-            class="rounded-lg border border-slate-200 px-3 py-2"
+            class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
             required
             [(ngModel)]="confirmPassword"
           />
         </label>
-        <p *ngIf="error" class="text-sm text-amber-700">{{ error }}</p>
+        <p *ngIf="error" class="text-sm text-amber-700 dark:text-amber-300">{{ error }}</p>
         <app-button [label]="'auth.register' | translate" type="submit"></app-button>
-        <div class="border-t border-slate-200 pt-4 grid gap-2">
-          <p class="text-sm text-slate-600 text-center">{{ 'auth.orContinue' | translate }}</p>
+        <div class="border-t border-slate-200 pt-4 grid gap-2 dark:border-slate-800">
+          <p class="text-sm text-slate-600 dark:text-slate-300 text-center">{{ 'auth.orContinue' | translate }}</p>
           <app-button variant="ghost" [label]="'auth.googleContinue' | translate" (action)="startGoogle()"></app-button>
         </div>
-        <p class="text-sm text-slate-600">
+        <p class="text-sm text-slate-600 dark:text-slate-300">
           {{ 'auth.haveAccount' | translate }}
-          <a routerLink="/login" class="text-indigo-600 font-medium">{{ 'auth.login' | translate }}</a>
+          <a routerLink="/login" class="text-indigo-600 dark:text-indigo-300 font-medium">{{ 'auth.login' | translate }}</a>
         </p>
       </form>
     </app-container>

--- a/frontend/src/app/pages/cart/cart.component.ts
+++ b/frontend/src/app/pages/cart/cart.component.ts
@@ -19,73 +19,75 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
       <div class="grid lg:grid-cols-[2fr_1fr] gap-6 items-start">
         <section class="grid gap-4">
           <div class="flex items-center justify-between">
-            <h1 class="text-2xl font-semibold text-slate-900">{{ 'cart.title' | translate }}</h1>
-            <span class="text-sm text-slate-600">{{ 'cart.items' | translate : { count: items().length } }}</span>
+            <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-50">{{ 'cart.title' | translate }}</h1>
+            <span class="text-sm text-slate-600 dark:text-slate-300">{{ 'cart.items' | translate : { count: items().length } }}</span>
           </div>
 
-          <div *ngIf="!items().length" class="border border-dashed border-slate-200 rounded-2xl p-10 text-center grid gap-3">
-            <p class="text-lg font-semibold text-slate-900">{{ 'cart.emptyTitle' | translate }}</p>
-            <p class="text-sm text-slate-600">{{ 'cart.emptyCopy' | translate }}</p>
+          <div *ngIf="!items().length" class="border border-dashed border-slate-200 rounded-2xl p-10 text-center grid gap-3 dark:border-slate-800">
+            <p class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'cart.emptyTitle' | translate }}</p>
+            <p class="text-sm text-slate-600 dark:text-slate-300">{{ 'cart.emptyCopy' | translate }}</p>
             <div class="flex justify-center">
               <app-button routerLink="/shop" [label]="'cart.backToShop' | translate"></app-button>
             </div>
           </div>
 
-          <div *ngFor="let item of items()" class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <div *ngFor="let item of items()" class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
             <div class="flex gap-4">
               <img
                 [src]="item.image ?? 'https://via.placeholder.com/120'"
                 [alt]="item.name"
-                class="h-24 w-24 rounded-xl object-cover border border-slate-100"
+                class="h-24 w-24 rounded-xl object-cover border border-slate-100 dark:border-slate-800"
               />
               <div class="flex-1 grid gap-2">
                 <div class="flex items-start justify-between">
                   <div>
-                    <p class="font-semibold text-slate-900">{{ item.name }}</p>
-                    <p class="text-sm text-slate-500">In stock: {{ item.stock }}</p>
+                    <p class="font-semibold text-slate-900 dark:text-slate-50">{{ item.name }}</p>
+                    <p class="text-sm text-slate-500 dark:text-slate-400">In stock: {{ item.stock }}</p>
                   </div>
-                  <button class="text-sm text-slate-500 hover:text-slate-900" (click)="remove(item.id)">Remove</button>
+                  <button class="text-sm text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-50" (click)="remove(item.id)">
+                    Remove
+                  </button>
                 </div>
                 <div class="flex items-center gap-3 text-sm">
                   <label class="flex items-center gap-2">
                     {{ 'cart.qty' | translate }}
                     <input
                       type="number"
-                      class="w-20 rounded-lg border border-slate-200 px-2 py-1"
+                      class="w-20 rounded-lg border border-slate-200 bg-white px-2 py-1 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
                       [value]="item.quantity"
                       (change)="onQuantityChange(item.id, $any($event.target).value)"
                       min="1"
                       [max]="item.stock"
                     />
                   </label>
-                  <span class="text-slate-600">
+                  <span class="text-slate-600 dark:text-slate-300">
                     {{ item.price | localizedCurrency : item.currency }} {{ 'cart.each' | translate }}
                   </span>
-                  <span class="font-semibold text-slate-900">
+                  <span class="font-semibold text-slate-900 dark:text-slate-50">
                     {{ item.price * item.quantity | localizedCurrency : item.currency }}
                   </span>
                 </div>
-                <p *ngIf="errorMsg" class="text-sm text-amber-700">{{ errorMsg }}</p>
+                <p *ngIf="errorMsg" class="text-sm text-amber-700 dark:text-amber-300">{{ errorMsg }}</p>
               </div>
             </div>
           </div>
         </section>
 
-        <aside class="rounded-2xl border border-slate-200 bg-white p-4 grid gap-4">
-          <h2 class="text-lg font-semibold text-slate-900">{{ 'cart.summary' | translate }}</h2>
-          <div class="flex items-center justify-between text-sm text-slate-700">
+        <aside class="rounded-2xl border border-slate-200 bg-white p-4 grid gap-4 dark:border-slate-800 dark:bg-slate-900">
+          <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'cart.summary' | translate }}</h2>
+          <div class="flex items-center justify-between text-sm text-slate-700 dark:text-slate-200">
             <span>{{ 'cart.subtotal' | translate }}</span>
             <span>{{ subtotal() | localizedCurrency : currency }}</span>
           </div>
-          <div class="flex items-center justify-between text-sm text-slate-700">
+          <div class="flex items-center justify-between text-sm text-slate-700 dark:text-slate-200">
             <span>{{ 'cart.shipping' | translate }}</span>
-            <span class="text-slate-500">{{ 'cart.calcAtCheckout' | translate }}</span>
+            <span class="text-slate-500 dark:text-slate-400">{{ 'cart.calcAtCheckout' | translate }}</span>
           </div>
-          <div class="flex items-center justify-between text-sm text-slate-700">
+          <div class="flex items-center justify-between text-sm text-slate-700 dark:text-slate-200">
             <span>{{ 'cart.tax' | translate }}</span>
-            <span class="text-slate-500">{{ 'cart.calcAtCheckout' | translate }}</span>
+            <span class="text-slate-500 dark:text-slate-400">{{ 'cart.calcAtCheckout' | translate }}</span>
           </div>
-          <div class="border-t border-slate-200 pt-3 flex items-center justify-between text-base font-semibold text-slate-900">
+          <div class="border-t border-slate-200 pt-3 flex items-center justify-between text-base font-semibold text-slate-900 dark:border-slate-800 dark:text-slate-50">
             <span>{{ 'cart.estimatedTotal' | translate }}</span>
             <span>{{ subtotal() | localizedCurrency : currency }}</span>
           </div>

--- a/frontend/src/app/pages/checkout/checkout.component.ts
+++ b/frontend/src/app/pages/checkout/checkout.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, AfterViewInit, OnDestroy, ViewChild, ElementRef } from '@angular/core';
+import { Component, AfterViewInit, OnDestroy, ViewChild, ElementRef, effect, EffectRef } from '@angular/core';
 import { FormsModule, NgForm } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { ContainerComponent } from '../../layout/container.component';
@@ -12,6 +12,7 @@ import { loadStripe, Stripe, StripeElements, StripeCardElement, StripeCardElemen
 import { ApiService } from '../../core/api.service';
 import { appConfig } from '../../core/app-config';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { ThemeMode, ThemeService } from '../../core/theme.service';
 
 type ShippingMethod = { id: string; label: string; amount: number; eta: string };
 
@@ -24,17 +25,17 @@ type ShippingMethod = { id: string; label: string; amount: number; eta: string }
       <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
       <div class="grid lg:grid-cols-[2fr_1fr] gap-6 items-start">
         <section class="grid gap-4">
-          <h1 class="text-2xl font-semibold text-slate-900">{{ 'checkout.title' | translate }}</h1>
+          <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-50">{{ 'checkout.title' | translate }}</h1>
           <div
             *ngIf="errorMessage"
-            class="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 flex items-start justify-between gap-3"
+            class="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 flex items-start justify-between gap-3 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100"
           >
             <span>{{ errorMessage }}</span>
             <app-button size="sm" variant="ghost" [label]="'checkout.retry' | translate" (action)="retryValidation()"></app-button>
           </div>
           <form #checkoutForm="ngForm" class="grid gap-4" (ngSubmit)="placeOrder(checkoutForm)">
-            <div class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
-              <p class="text-sm font-semibold text-slate-800 uppercase tracking-[0.2em]">{{ 'checkout.step1' | translate }}</p>
+            <div class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+              <p class="text-sm font-semibold text-slate-800 uppercase tracking-[0.2em] dark:text-slate-200">{{ 'checkout.step1' | translate }}</p>
               <label class="flex items-center gap-2 text-sm">
                 <input type="radio" name="checkoutMode" value="guest" [(ngModel)]="mode" required />
                 {{ 'checkout.guest' | translate }}
@@ -45,32 +46,32 @@ type ShippingMethod = { id: string; label: string; amount: number; eta: string }
               </label>
             </div>
 
-            <div class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
-              <p class="text-sm font-semibold text-slate-800 uppercase tracking-[0.2em]">{{ 'checkout.step2' | translate }}</p>
+            <div class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+              <p class="text-sm font-semibold text-slate-800 uppercase tracking-[0.2em] dark:text-slate-200">{{ 'checkout.step2' | translate }}</p>
               <div class="grid sm:grid-cols-2 gap-3">
                 <label class="text-sm grid gap-1">
                   {{ 'checkout.name' | translate }}
-                  <input class="rounded-lg border border-slate-200 px-3 py-2" name="name" [(ngModel)]="address.name" required />
+                  <input class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400" name="name" [(ngModel)]="address.name" required />
                 </label>
                 <label class="text-sm grid gap-1">
                   {{ 'checkout.email' | translate }}
-                  <input class="rounded-lg border border-slate-200 px-3 py-2" name="email" [(ngModel)]="address.email" type="email" required />
+                  <input class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400" name="email" [(ngModel)]="address.email" type="email" required />
                 </label>
                 <label class="text-sm grid gap-1 sm:col-span-2">
                   {{ 'checkout.line1' | translate }}
-                  <input class="rounded-lg border border-slate-200 px-3 py-2" name="line1" [(ngModel)]="address.line1" required />
+                  <input class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400" name="line1" [(ngModel)]="address.line1" required />
                 </label>
                 <label class="text-sm grid gap-1">
                   {{ 'checkout.city' | translate }}
-                  <input class="rounded-lg border border-slate-200 px-3 py-2" name="city" [(ngModel)]="address.city" required />
+                  <input class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400" name="city" [(ngModel)]="address.city" required />
                 </label>
                 <label class="text-sm grid gap-1">
                   {{ 'checkout.postal' | translate }}
-                  <input class="rounded-lg border border-slate-200 px-3 py-2" name="postal" [(ngModel)]="address.postal" required />
+                  <input class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400" name="postal" [(ngModel)]="address.postal" required />
                 </label>
                 <label class="text-sm grid gap-1 sm:col-span-2">
                   {{ 'checkout.country' | translate }}
-                  <select class="rounded-lg border border-slate-200 px-3 py-2" name="country" [(ngModel)]="address.country" required>
+                  <select class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100" name="country" [(ngModel)]="address.country" required>
                     <option value="">{{ 'checkout.countrySelect' | translate }}</option>
                     <option *ngFor="let c of countries" [value]="c">{{ c }}</option>
                   </select>
@@ -80,48 +81,58 @@ type ShippingMethod = { id: string; label: string; amount: number; eta: string }
                 <input type="checkbox" [(ngModel)]="saveAddress" name="saveAddress" />
                 {{ 'checkout.saveAddress' | translate }}
               </label>
-              <p *ngIf="addressError" class="text-sm text-amber-700">{{ addressError }}</p>
+              <p *ngIf="addressError" class="text-sm text-amber-700 dark:text-amber-300">{{ addressError }}</p>
             </div>
 
-            <div class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
-              <p class="text-sm font-semibold text-slate-800 uppercase tracking-[0.2em]">{{ 'checkout.step3' | translate }}</p>
+            <div class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+              <p class="text-sm font-semibold text-slate-800 uppercase tracking-[0.2em] dark:text-slate-200">{{ 'checkout.step3' | translate }}</p>
               <label
                 *ngFor="let method of shippingMethods"
-                class="flex items-center justify-between rounded-lg border px-3 py-2 text-sm"
-                [class.border-slate-900]="shipping === method.id"
+                class="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-950/30"
+                [ngClass]="shipping === method.id ? 'border-slate-900 dark:border-slate-50' : ''"
               >
                 <span class="flex flex-col">
-                  <span class="font-semibold text-slate-900">{{ method.label }}</span>
-                  <span class="text-slate-500">{{ method.eta }}</span>
+                  <span class="font-semibold text-slate-900 dark:text-slate-50">{{ method.label }}</span>
+                  <span class="text-slate-500 dark:text-slate-400">{{ method.eta }}</span>
                 </span>
                 <span class="flex items-center gap-3">
-                  <span class="font-semibold text-slate-900">{{ method.amount | localizedCurrency : currency }}</span>
+                  <span class="font-semibold text-slate-900 dark:text-slate-50">{{ method.amount | localizedCurrency : currency }}</span>
                   <input type="radio" name="shipping" [value]="method.id" [(ngModel)]="shipping" required />
                 </span>
               </label>
             </div>
 
-            <div class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
-              <p class="text-sm font-semibold text-slate-800 uppercase tracking-[0.2em]">{{ 'checkout.step4' | translate }}</p>
+            <div class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+              <p class="text-sm font-semibold text-slate-800 uppercase tracking-[0.2em] dark:text-slate-200">{{ 'checkout.step4' | translate }}</p>
               <div class="flex gap-3">
                 <input
-                  class="rounded-lg border border-slate-200 px-3 py-2 flex-1"
+                  class="rounded-lg border border-slate-200 bg-white px-3 py-2 flex-1 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
                   [(ngModel)]="promo"
                   name="promo"
                   [placeholder]="'checkout.promoPlaceholder' | translate"
                 />
                 <app-button size="sm" [label]="'checkout.apply' | translate" (action)="applyPromo()"></app-button>
               </div>
-              <p class="text-sm" [class.text-emerald-700]="promoMessage.startsWith('Applied')" [class.text-amber-700]="promoMessage.startsWith('Invalid')" *ngIf="promoMessage">
+              <p
+                class="text-sm"
+                [ngClass]="
+                  promoMessage.startsWith('Applied')
+                    ? 'text-emerald-700 dark:text-emerald-300'
+                    : promoMessage.startsWith('Invalid')
+                      ? 'text-amber-700 dark:text-amber-300'
+                      : 'text-slate-700 dark:text-slate-300'
+                "
+                *ngIf="promoMessage"
+              >
                 {{ promoMessage }}
               </p>
             </div>
 
-            <div class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4">
-              <p class="text-sm font-semibold text-slate-800 uppercase tracking-[0.2em]">{{ 'checkout.step5' | translate }}</p>
-              <div class="border border-dashed border-slate-200 rounded-lg p-3 text-sm">
+            <div class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+              <p class="text-sm font-semibold text-slate-800 uppercase tracking-[0.2em] dark:text-slate-200">{{ 'checkout.step5' | translate }}</p>
+              <div class="border border-dashed border-slate-200 rounded-lg p-3 text-sm dark:border-slate-700">
                 <div #cardHost class="min-h-[48px]"></div>
-                <p *ngIf="cardError" class="text-rose-700 text-xs mt-2">{{ cardError }}</p>
+                <p *ngIf="cardError" class="text-rose-700 dark:text-rose-300 text-xs mt-2">{{ cardError }}</p>
               </div>
             </div>
 
@@ -132,30 +143,30 @@ type ShippingMethod = { id: string; label: string; amount: number; eta: string }
           </form>
         </section>
 
-        <aside class="rounded-2xl border border-slate-200 bg-white p-4 grid gap-4">
-          <h2 class="text-lg font-semibold text-slate-900">{{ 'checkout.summary' | translate }}</h2>
-          <div class="grid gap-2 text-sm text-slate-700">
+        <aside class="rounded-2xl border border-slate-200 bg-white p-4 grid gap-4 dark:border-slate-800 dark:bg-slate-900">
+          <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'checkout.summary' | translate }}</h2>
+          <div class="grid gap-2 text-sm text-slate-700 dark:text-slate-200">
             <div *ngFor="let item of items()">
               <div class="flex justify-between">
                 <span>{{ item.name }} × {{ item.quantity }}</span>
                 <span>{{ item.price * item.quantity | localizedCurrency : item.currency }}</span>
               </div>
-              <p class="text-xs text-slate-500">Stock: {{ item.stock }}</p>
+              <p class="text-xs text-slate-500 dark:text-slate-400">Stock: {{ item.stock }}</p>
             </div>
           </div>
-          <div class="flex items-center justify-between text-sm text-slate-700">
+          <div class="flex items-center justify-between text-sm text-slate-700 dark:text-slate-200">
             <span>{{ 'checkout.subtotal' | translate }}</span>
             <span>{{ subtotal() | localizedCurrency : currency }}</span>
           </div>
-          <div class="flex items-center justify-between text-sm text-slate-700">
+          <div class="flex items-center justify-between text-sm text-slate-700 dark:text-slate-200">
             <span>{{ 'checkout.shipping' | translate }}</span>
             <span>{{ shippingAmount | localizedCurrency : currency }}</span>
           </div>
-          <div class="flex items-center justify-between text-sm text-slate-700">
+          <div class="flex items-center justify-between text-sm text-slate-700 dark:text-slate-200">
             <span>{{ 'checkout.promo' | translate }}</span>
-            <span class="text-emerald-700">-{{ discount | localizedCurrency : currency }}</span>
+            <span class="text-emerald-700 dark:text-emerald-300">-{{ discount | localizedCurrency : currency }}</span>
           </div>
-          <div class="border-t border-slate-200 pt-3 flex items-center justify-between text-base font-semibold text-slate-900">
+          <div class="border-t border-slate-200 pt-3 flex items-center justify-between text-base font-semibold text-slate-900 dark:border-slate-800 dark:text-slate-50">
             <span>{{ 'checkout.estimatedTotal' | translate }}</span>
             <span>{{ total | localizedCurrency : currency }}</span>
           </div>
@@ -204,18 +215,26 @@ export class CheckoutComponent implements AfterViewInit, OnDestroy {
   private clientSecret: string | null = null;
   syncing = false;
   placing = false;
+  private stripeThemeEffect?: EffectRef;
 
   constructor(
     private cart: CartStore,
     private router: Router,
     private cartApi: CartApi,
     private api: ApiService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private theme: ThemeService
   ) {
     const saved = this.loadSavedAddress();
     if (saved) {
       this.address = saved;
     }
+    this.stripeThemeEffect = effect(() => {
+      const mode = this.theme.mode()();
+      if (this.card) {
+        this.card.update({ style: this.buildStripeCardStyle(mode) });
+      }
+    });
   }
 
   items = this.cart.items;
@@ -322,6 +341,7 @@ export class CheckoutComponent implements AfterViewInit, OnDestroy {
 
   ngOnDestroy(): void {
     if (this.card) this.card.destroy();
+    this.stripeThemeEffect?.destroy();
   }
 
   private async setupStripe(): Promise<void> {
@@ -336,13 +356,38 @@ export class CheckoutComponent implements AfterViewInit, OnDestroy {
       return;
     }
     this.elements = this.stripe.elements();
-    this.card = this.elements.create('card');
+    this.card = this.elements.create('card', { style: this.buildStripeCardStyle(this.theme.mode()()) });
     if (this.cardHost) {
       this.card.mount(this.cardHost.nativeElement);
       this.card.on('change', (event: StripeCardElementChangeEvent) => {
         this.cardError = event.error ? event.error.message ?? 'Card error' : null;
       });
     }
+  }
+
+  private buildStripeCardStyle(mode: ThemeMode) {
+    const base =
+      mode === 'dark'
+        ? {
+            color: '#f8fafc',
+            iconColor: '#f8fafc',
+            fontFamily: 'Inter, system-ui, sans-serif',
+            fontSize: '16px',
+            '::placeholder': { color: '#94a3b8' }
+          }
+        : {
+            color: '#0f172a',
+            iconColor: '#0f172a',
+            fontFamily: 'Inter, system-ui, sans-serif',
+            fontSize: '16px',
+            '::placeholder': { color: '#64748b' }
+          };
+    return {
+      base,
+      invalid: {
+        color: mode === 'dark' ? '#fca5a5' : '#b91c1c'
+      }
+    };
   }
 
   private getStripePublishableKey(): string | null {

--- a/frontend/src/app/pages/checkout/success.component.ts
+++ b/frontend/src/app/pages/checkout/success.component.ts
@@ -14,11 +14,11 @@ import { LocalizedCurrencyPipe } from '../../shared/localized-currency.pipe';
   template: `
     <app-container classes="py-10 grid gap-6">
       <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
-      <div class="grid gap-4 rounded-2xl border border-emerald-200 bg-emerald-50 p-6 text-emerald-900">
+      <div class="grid gap-4 rounded-2xl border border-emerald-200 bg-emerald-50 p-6 text-emerald-900 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-100">
         <p class="text-sm uppercase tracking-[0.3em] font-semibold">Order confirmed</p>
-        <h1 class="text-2xl font-semibold text-emerald-900">Thank you for your purchase!</h1>
-        <p class="text-sm text-emerald-800">We emailed you a confirmation. You can continue shopping or view your orders.</p>
-        <ul class="text-sm text-emerald-800 list-disc list-inside grid gap-1">
+        <h1 class="text-2xl font-semibold text-emerald-900 dark:text-emerald-100">Thank you for your purchase!</h1>
+        <p class="text-sm text-emerald-800 dark:text-emerald-200">We emailed you a confirmation. You can continue shopping or view your orders.</p>
+        <ul class="text-sm text-emerald-800 dark:text-emerald-200 list-disc list-inside grid gap-1">
           <li>Track your order from your account once it's available.</li>
           <li>Save your address to speed up next checkout.</li>
           <li>Need help? Reply to the confirmation email.</li>
@@ -29,9 +29,9 @@ import { LocalizedCurrencyPipe } from '../../shared/localized-currency.pipe';
         </div>
       </div>
 
-      <aside class="rounded-2xl border border-slate-200 bg-white p-4 grid gap-3">
-        <h2 class="text-lg font-semibold text-slate-900">Order summary</h2>
-        <div class="grid gap-2 text-sm text-slate-700">
+      <aside class="rounded-2xl border border-slate-200 bg-white p-4 grid gap-3 dark:border-slate-800 dark:bg-slate-900">
+        <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">Order summary</h2>
+        <div class="grid gap-2 text-sm text-slate-700 dark:text-slate-200">
           <div *ngFor="let item of items()">
             <div class="flex justify-between">
               <span>{{ item.name }} × {{ item.quantity }}</span>
@@ -39,7 +39,7 @@ import { LocalizedCurrencyPipe } from '../../shared/localized-currency.pipe';
             </div>
           </div>
         </div>
-        <div class="flex items-center justify-between text-base font-semibold text-slate-900 pt-2 border-t border-slate-200">
+        <div class="flex items-center justify-between text-base font-semibold text-slate-900 pt-2 border-t border-slate-200 dark:border-slate-800 dark:text-slate-50">
           <span>Total</span>
           <span>{{ subtotal() | localizedCurrency : currency }}</span>
         </div>

--- a/frontend/src/app/pages/error/error.component.ts
+++ b/frontend/src/app/pages/error/error.component.ts
@@ -9,12 +9,12 @@ import { RouterLink } from '@angular/router';
   template: `
     <div class="text-center grid gap-4 py-16" role="alert" aria-live="assertive">
       <p class="text-sm uppercase tracking-[0.3em] text-red-500">Error</p>
-      <h1 class="text-3xl font-semibold text-slate-900">Something went wrong</h1>
-      <p class="text-slate-600">We've logged the issue. Please try again, return home, or contact support.</p>
+      <h1 class="text-3xl font-semibold text-slate-900 dark:text-slate-50">Something went wrong</h1>
+      <p class="text-slate-600 dark:text-slate-300">We've logged the issue. Please try again, return home, or contact support.</p>
       <div class="flex justify-center gap-3 flex-wrap">
         <app-button label="Retry" (action)="onRetry()"></app-button>
         <app-button variant="ghost" routerLink="/" label="Go home"></app-button>
-        <a class="text-sm text-indigo-600 font-medium" href="mailto:hello@adrianaart.com">Contact support</a>
+        <a class="text-sm text-indigo-600 dark:text-indigo-300 font-medium" href="mailto:hello@adrianaart.com">Contact support</a>
       </div>
     </div>
   `

--- a/frontend/src/app/pages/home/home.component.ts
+++ b/frontend/src/app/pages/home/home.component.ts
@@ -19,18 +19,18 @@ import { Meta, Title } from '@angular/platform-browser';
     <section class="grid gap-10">
       <div class="grid gap-6 lg:grid-cols-[1.2fr_1fr] items-center">
         <div class="grid gap-4">
-          <p class="uppercase text-sm tracking-[0.3em] text-slate-500">{{ 'app.tagline' | translate }}</p>
-          <h1 class="text-3xl sm:text-4xl lg:text-5xl font-semibold leading-tight text-slate-900">
+          <p class="uppercase text-sm tracking-[0.3em] text-slate-500 dark:text-slate-400">{{ 'app.tagline' | translate }}</p>
+          <h1 class="text-3xl sm:text-4xl lg:text-5xl font-semibold leading-tight text-slate-900 dark:text-slate-50">
             {{ 'home.headline' | translate }}
           </h1>
-          <p class="text-lg text-slate-600">{{ 'home.subhead' | translate }}</p>
+          <p class="text-lg text-slate-600 dark:text-slate-300">{{ 'home.subhead' | translate }}</p>
           <div class="flex flex-wrap gap-3">
             <app-button [label]="'home.ctaShop' | translate" [routerLink]="['/shop']"></app-button>
             <app-button [label]="'home.ctaAdmin' | translate" variant="ghost" [routerLink]="['/admin']"></app-button>
           </div>
         </div>
         <div class="relative">
-          <div class="absolute -inset-4 rounded-3xl bg-slate-900/5 blur-xl"></div>
+          <div class="absolute -inset-4 rounded-3xl bg-slate-900/5 blur-xl dark:bg-slate-50/10"></div>
           <app-card class="relative">
             <div class="aspect-video rounded-2xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-700 grid place-items-center text-white text-xl font-semibold">
               Hero image slot
@@ -41,7 +41,7 @@ import { Meta, Title } from '@angular/platform-browser';
 
       <div class="grid gap-4">
         <div class="flex items-center justify-between">
-          <h2 class="text-xl font-semibold text-slate-900">{{ 'home.featured' | translate }}</h2>
+          <h2 class="text-xl font-semibold text-slate-900 dark:text-slate-50">{{ 'home.featured' | translate }}</h2>
           <app-button [label]="'home.viewAll' | translate" variant="ghost" [routerLink]="['/shop']"></app-button>
         </div>
 
@@ -49,10 +49,10 @@ import { Meta, Title } from '@angular/platform-browser';
           <app-skeleton *ngFor="let i of skeletons" height="260px"></app-skeleton>
         </div>
 
-          <div *ngIf="featuredError()" class="border border-amber-200 bg-amber-50 rounded-2xl p-4 flex items-center justify-between">
+          <div *ngIf="featuredError()" class="border border-amber-200 bg-amber-50 rounded-2xl p-4 flex items-center justify-between dark:border-amber-900/40 dark:bg-amber-950/30">
             <div>
-              <p class="font-semibold text-amber-900">{{ 'home.featuredError.title' | translate }}</p>
-              <p class="text-sm text-amber-800">{{ 'home.featuredError.copy' | translate }}</p>
+              <p class="font-semibold text-amber-900 dark:text-amber-100">{{ 'home.featuredError.title' | translate }}</p>
+              <p class="text-sm text-amber-800 dark:text-amber-200">{{ 'home.featuredError.copy' | translate }}</p>
             </div>
             <app-button [label]="'shop.retry' | translate" size="sm" (action)="loadFeatured()"></app-button>
           </div>
@@ -61,14 +61,14 @@ import { Meta, Title } from '@angular/platform-browser';
           <app-product-card *ngFor="let product of featured" [product]="product"></app-product-card>
         </div>
 
-        <div *ngIf="!featuredLoading() && !featuredError() && !featured.length" class="text-sm text-slate-600">
+        <div *ngIf="!featuredLoading() && !featuredError() && !featured.length" class="text-sm text-slate-600 dark:text-slate-300">
           {{ 'home.noFeatured' | translate }}
         </div>
       </div>
 
       <div *ngIf="recentlyViewed.length" class="grid gap-4">
         <div class="flex items-center justify-between">
-          <h2 class="text-xl font-semibold text-slate-900">{{ 'product.recentlyViewed' | translate }}</h2>
+          <h2 class="text-xl font-semibold text-slate-900 dark:text-slate-50">{{ 'product.recentlyViewed' | translate }}</h2>
           <app-button [label]="'home.viewAll' | translate" variant="ghost" [routerLink]="['/shop']"></app-button>
         </div>
         <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -77,7 +77,7 @@ import { Meta, Title } from '@angular/platform-browser';
       </div>
 
       <div class="grid gap-4">
-        <h2 class="text-xl font-semibold text-slate-900">{{ 'home.why' | translate }}</h2>
+        <h2 class="text-xl font-semibold text-slate-900 dark:text-slate-50">{{ 'home.why' | translate }}</h2>
         <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
           <app-card [title]="'home.cards.strictTitle' | translate">
             <p>{{ 'home.cards.strict' | translate }}</p>

--- a/frontend/src/app/pages/not-found/not-found.component.ts
+++ b/frontend/src/app/pages/not-found/not-found.component.ts
@@ -8,13 +8,13 @@ import { ButtonComponent } from '../../shared/button.component';
   imports: [RouterLink, ButtonComponent],
   template: `
     <div class="text-center grid gap-4 py-16">
-      <p class="text-sm uppercase tracking-[0.3em] text-slate-500">404</p>
-      <h1 class="text-3xl font-semibold text-slate-900">Page not found</h1>
-      <p class="text-slate-600">The page you are looking for doesn't exist. Try heading back home or search the shop.</p>
+      <p class="text-sm uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">404</p>
+      <h1 class="text-3xl font-semibold text-slate-900 dark:text-slate-50">Page not found</h1>
+      <p class="text-slate-600 dark:text-slate-300">The page you are looking for doesn't exist. Try heading back home or search the shop.</p>
       <div class="flex justify-center gap-3 flex-wrap">
         <app-button routerLink="/" label="Back to home"></app-button>
         <app-button routerLink="/shop" variant="ghost" label="Browse shop"></app-button>
-        <a class="text-sm text-indigo-600 font-medium" href="mailto:hello@adrianaart.com">Contact support</a>
+        <a class="text-sm text-indigo-600 dark:text-indigo-300 font-medium" href="mailto:hello@adrianaart.com">Contact support</a>
       </div>
     </div>
   `

--- a/frontend/src/app/pages/product/product.component.ts
+++ b/frontend/src/app/pages/product/product.component.ts
@@ -51,7 +51,7 @@ import { Router } from '@angular/router';
           <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
           <div class="grid gap-10 lg:grid-cols-2">
             <div class="space-y-4">
-              <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white cursor-zoom-in" (click)="openPreview()">
+              <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white cursor-zoom-in dark:border-slate-800 dark:bg-slate-900" (click)="openPreview()">
                 <img
                   [ngSrc]="activeImage"
                   [alt]="product.name"
@@ -66,8 +66,8 @@ import { Router } from '@angular/router';
               <div class="flex gap-3">
                 <button
                   *ngFor="let image of product.images ?? []; let idx = index"
-                  class="h-20 w-20 rounded-xl border"
-                  [ngClass]="idx === activeImageIndex ? 'border-slate-900' : 'border-slate-200'"
+                  class="h-20 w-20 rounded-xl border border-slate-200 dark:border-slate-700"
+                  [ngClass]="idx === activeImageIndex ? 'border-slate-900 dark:border-slate-50' : ''"
                   type="button"
                   (click)="setActiveImage(idx)"
                 >
@@ -86,30 +86,30 @@ import { Router } from '@angular/router';
 
             <div class="space-y-5">
               <div class="space-y-2">
-                <p class="text-xs uppercase tracking-[0.3em] text-slate-500">{{ 'product.handmade' | translate }}</p>
-                <h1 class="text-3xl font-semibold text-slate-900">{{ product.name }}</h1>
-              <p class="text-lg font-semibold text-slate-900">
+                <p class="text-xs uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">{{ 'product.handmade' | translate }}</p>
+                <h1 class="text-3xl font-semibold text-slate-900 dark:text-slate-50">{{ product.name }}</h1>
+              <p class="text-lg font-semibold text-slate-900 dark:text-slate-50">
                   {{ product.base_price | localizedCurrency : product.currency }}
                 </p>
-                <div class="flex items-center gap-2 text-sm text-amber-700" *ngIf="product.rating_count">
+                <div class="flex items-center gap-2 text-sm text-amber-700 dark:text-amber-300" *ngIf="product.rating_count">
                   ★ {{ product.rating_average?.toFixed(1) ?? '0.0' }} ·
                   {{ 'product.reviews' | translate : { count: product.rating_count } }}
                 </div>
               </div>
 
-              <p class="text-sm text-slate-700 leading-relaxed" *ngIf="product.long_description">
+              <p class="text-sm text-slate-700 dark:text-slate-200 leading-relaxed" *ngIf="product.long_description">
                 {{ product.long_description }}
               </p>
 
-              <div class="rounded-xl bg-amber-50 border border-amber-200 p-3 text-sm text-amber-900">
+              <div class="rounded-xl bg-amber-50 border border-amber-200 p-3 text-sm text-amber-900 dark:bg-amber-950/30 dark:border-amber-900/40 dark:text-amber-100">
                 {{ 'product.uniqueness' | translate }}
               </div>
 
               <div class="space-y-3">
-                <label *ngIf="product.variants?.length" class="grid gap-1 text-sm font-medium text-slate-800">
+                <label *ngIf="product.variants?.length" class="grid gap-1 text-sm font-medium text-slate-800 dark:text-slate-200">
                   {{ 'product.variant' | translate }}
                   <select
-                    class="rounded-lg border border-slate-200 px-3 py-2 text-sm"
+                    class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
                     [(ngModel)]="selectedVariantId"
                   >
                     <option *ngFor="let variant of product.variants" [value]="variant.id">
@@ -118,12 +118,12 @@ import { Router } from '@angular/router';
                   </select>
                 </label>
 
-                <label class="grid gap-1 text-sm font-medium text-slate-800">
+                <label class="grid gap-1 text-sm font-medium text-slate-800 dark:text-slate-200">
                   {{ 'product.quantity' | translate }}
                   <input
                     type="number"
                     min="1"
-                    class="w-24 rounded-lg border border-slate-200 px-3 py-2"
+                    class="w-24 rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
                     [(ngModel)]="quantity"
                   />
                 </label>
@@ -150,7 +150,7 @@ import { Router } from '@angular/router';
               <div class="flex flex-wrap gap-2" *ngIf="product.tags?.length">
                 <span
                   *ngFor="let tag of product.tags"
-                  class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+                  class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200"
                 >
                   {{ tag.name ?? tag }}
                 </span>
@@ -162,8 +162,8 @@ import { Router } from '@angular/router';
 
       <div *ngIf="recentlyViewed.length" class="mt-12 grid gap-4">
         <div class="flex items-center justify-between">
-          <h3 class="text-lg font-semibold text-slate-900">{{ 'product.recentlyViewed' | translate }}</h3>
-          <a routerLink="/shop" class="text-sm font-medium text-indigo-600">{{ 'product.backToShop' | translate }}</a>
+          <h3 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'product.recentlyViewed' | translate }}</h3>
+          <a routerLink="/shop" class="text-sm font-medium text-indigo-600 dark:text-indigo-300">{{ 'product.backToShop' | translate }}</a>
         </div>
         <div class="flex gap-4 overflow-x-auto pb-2">
           <app-button
@@ -182,9 +182,9 @@ import { Router } from '@angular/router';
                 loading="lazy"
                 decoding="async"
               />
-              <div class="grid gap-1">
-                <p class="text-sm font-semibold text-slate-900">{{ item.name }}</p>
-                <p class="text-sm text-slate-600">
+                <div class="grid gap-1">
+                <p class="text-sm font-semibold text-slate-900 dark:text-slate-50">{{ item.name }}</p>
+                <p class="text-sm text-slate-600 dark:text-slate-300">
                   {{ item.base_price | localizedCurrency : item.currency }}
                 </p>
               </div>
@@ -220,9 +220,9 @@ import { Router } from '@angular/router';
       </div>
 
       <ng-template #missing>
-        <div class="border border-dashed border-slate-200 rounded-2xl p-10 text-center">
-          <p class="text-lg font-semibold text-slate-900">{{ 'product.notFound' | translate }}</p>
-          <a routerLink="/shop" class="text-indigo-600 font-medium">{{ 'product.backToShop' | translate }}</a>
+        <div class="border border-dashed border-slate-200 rounded-2xl p-10 text-center dark:border-slate-800">
+          <p class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'product.notFound' | translate }}</p>
+          <a routerLink="/shop" class="text-indigo-600 dark:text-indigo-300 font-medium">{{ 'product.backToShop' | translate }}</a>
         </div>
       </ng-template>
     </app-container>

--- a/frontend/src/app/pages/shop/shop.component.ts
+++ b/frontend/src/app/pages/shop/shop.component.ts
@@ -33,11 +33,11 @@ import { Meta, Title } from '@angular/platform-browser';
     <app-container classes="py-10 grid gap-6">
       <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
       <div class="grid gap-8 lg:grid-cols-[280px_1fr]">
-        <aside class="border border-slate-200 rounded-2xl p-4 bg-white h-fit space-y-6">
+        <aside class="border border-slate-200 rounded-2xl p-4 bg-white h-fit space-y-6 dark:border-slate-800 dark:bg-slate-900">
           <div class="space-y-3">
             <div class="flex items-center justify-between">
-              <h2 class="text-lg font-semibold text-slate-900">{{ 'shop.filters' | translate }}</h2>
-              <button class="text-sm text-indigo-600 font-medium" type="button" (click)="resetFilters()">
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'shop.filters' | translate }}</h2>
+              <button class="text-sm text-indigo-600 font-medium dark:text-indigo-300" type="button" (click)="resetFilters()">
                 {{ 'shop.reset' | translate }}
               </button>
             </div>
@@ -51,27 +51,27 @@ import { Meta, Title } from '@angular/platform-browser';
           </div>
 
           <div class="space-y-3">
-            <p class="text-sm font-semibold text-slate-800">{{ 'shop.categories' | translate }}</p>
+            <p class="text-sm font-semibold text-slate-800 dark:text-slate-200">{{ 'shop.categories' | translate }}</p>
             <div class="space-y-2 max-h-48 overflow-auto pr-1">
               <label
                 *ngFor="let category of categories"
-                class="flex items-center gap-2 text-sm text-slate-700"
+                class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300"
               >
                 <input
                   type="radio"
                   name="category"
-                  class="h-4 w-4 rounded border-slate-300"
+                  class="h-4 w-4 rounded border-slate-300 dark:border-slate-600"
                   [value]="category.slug"
                   [(ngModel)]="filters.category_slug"
                   (change)="applyFilters()"
                 />
                 <span>{{ category.name }}</span>
               </label>
-              <label class="flex items-center gap-2 text-sm text-slate-700">
+              <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
                 <input
                   type="radio"
                   name="category"
-                  class="h-4 w-4 rounded border-slate-300"
+                  class="h-4 w-4 rounded border-slate-300 dark:border-slate-600"
                   value=""
                   [(ngModel)]="filters.category_slug"
                   (change)="applyFilters()"
@@ -82,7 +82,7 @@ import { Meta, Title } from '@angular/platform-browser';
           </div>
 
           <div class="space-y-3">
-            <p class="text-sm font-semibold text-slate-800">{{ 'shop.priceRange' | translate }}</p>
+            <p class="text-sm font-semibold text-slate-800 dark:text-slate-200">{{ 'shop.priceRange' | translate }}</p>
             <div class="grid gap-3">
               <div class="flex items-center gap-3">
                 <input type="range" min="0" max="500" step="5" [(ngModel)]="filters.min_price" (change)="applyFilters()" aria-label="Minimum price" />
@@ -94,17 +94,17 @@ import { Meta, Title } from '@angular/platform-browser';
                 <app-input [label]="'shop.max' | translate" type="number" [(value)]="filters.max_price" (ngModelChange)="applyFilters()">
                 </app-input>
               </div>
-              <p class="text-xs text-slate-500">{{ 'shop.priceHint' | translate }}</p>
+              <p class="text-xs text-slate-500 dark:text-slate-400">{{ 'shop.priceHint' | translate }}</p>
             </div>
           </div>
 
           <div class="space-y-3" *ngIf="allTags.size">
-            <p class="text-sm font-semibold text-slate-800">{{ 'shop.tags' | translate }}</p>
+            <p class="text-sm font-semibold text-slate-800 dark:text-slate-200">{{ 'shop.tags' | translate }}</p>
             <div class="flex flex-wrap gap-2">
               <button
                 type="button"
                 class="rounded-full border px-3 py-1 text-xs font-medium transition"
-                [ngClass]="filters.tags.has(tag) ? 'bg-slate-900 text-white border-slate-900' : 'border-slate-200 text-slate-700'"
+                [ngClass]="filters.tags.has(tag) ? 'bg-slate-900 text-white border-slate-900 dark:bg-slate-50 dark:text-slate-900 dark:border-slate-50' : 'border-slate-200 text-slate-700 hover:border-slate-300 hover:text-slate-900 dark:border-slate-700 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-slate-50'"
                 *ngFor="let tag of allTags"
                 (click)="toggleTag(tag)"
               >
@@ -118,17 +118,17 @@ import { Meta, Title } from '@angular/platform-browser';
           <div class="flex flex-col sm:flex-row sm:items-center gap-3 justify-between">
             <div class="flex items-center gap-3">
               <input
-                class="w-64 max-w-full rounded-lg border border-slate-200 px-3 py-2 text-slate-900 shadow-sm focus:border-slate-400 focus:outline-none"
+                class="w-64 max-w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 shadow-sm focus:border-slate-400 focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
                 [placeholder]="'shop.searchPlaceholder' | translate"
                 [(ngModel)]="filters.search"
                 (keyup.enter)="onSearch()"
               />
               <app-button [label]="'shop.search' | translate" size="sm" (action)="onSearch()"></app-button>
             </div>
-            <label class="flex items-center gap-2 text-sm text-slate-700">
+            <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
               <span>{{ 'shop.sort' | translate }}</span>
               <select
-                class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm"
+                class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
                 [(ngModel)]="filters.sort"
                 (change)="applyFilters()"
               >
@@ -141,18 +141,18 @@ import { Meta, Title } from '@angular/platform-browser';
             <app-skeleton *ngFor="let i of placeholders" height="260px"></app-skeleton>
           </div>
 
-          <div *ngIf="hasError()" class="border border-amber-200 bg-amber-50 rounded-2xl p-6 text-center grid gap-3">
-            <p class="text-lg font-semibold text-amber-900">{{ 'shop.errorTitle' | translate }}</p>
-            <p class="text-sm text-amber-800">{{ 'shop.errorCopy' | translate }}</p>
+          <div *ngIf="hasError()" class="border border-amber-200 bg-amber-50 rounded-2xl p-6 text-center grid gap-3 dark:border-amber-900/40 dark:bg-amber-950/30">
+            <p class="text-lg font-semibold text-amber-900 dark:text-amber-100">{{ 'shop.errorTitle' | translate }}</p>
+            <p class="text-sm text-amber-800 dark:text-amber-200">{{ 'shop.errorCopy' | translate }}</p>
             <div class="flex justify-center gap-3">
               <app-button [label]="'shop.retry' | translate" size="sm" (action)="loadProducts()"></app-button>
               <app-button [label]="'shop.reset' | translate" size="sm" variant="ghost" (action)="resetFilters()"></app-button>
             </div>
           </div>
 
-          <div *ngIf="!loading() && !hasError() && products.length === 0" class="border border-dashed border-slate-200 rounded-2xl p-10 text-center grid gap-2">
-            <p class="text-lg font-semibold text-slate-900">{{ 'shop.noResults' | translate }}</p>
-            <p class="text-sm text-slate-600">{{ 'shop.tryAdjust' | translate }}</p>
+          <div *ngIf="!loading() && !hasError() && products.length === 0" class="border border-dashed border-slate-200 rounded-2xl p-10 text-center grid gap-2 dark:border-slate-800">
+            <p class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'shop.noResults' | translate }}</p>
+            <p class="text-sm text-slate-600 dark:text-slate-300">{{ 'shop.tryAdjust' | translate }}</p>
             <div class="flex justify-center gap-3">
               <app-button [label]="'shop.reset' | translate" size="sm" variant="ghost" (action)="resetFilters()"></app-button>
               <app-button [label]="'shop.backHome' | translate" size="sm" variant="ghost" routerLink="/"></app-button>
@@ -163,7 +163,7 @@ import { Meta, Title } from '@angular/platform-browser';
             <app-product-card *ngFor="let product of products" [product]="product"></app-product-card>
           </div>
 
-          <div *ngIf="pageMeta" class="flex items-center justify-between text-sm text-slate-700">
+          <div *ngIf="pageMeta" class="flex items-center justify-between text-sm text-slate-700 dark:text-slate-300">
             <div>
               {{ 'shop.pageMeta' | translate : { page: pageMeta.page, totalPages: pageMeta.total_pages, totalItems: pageMeta.total_items } }}
             </div>

--- a/frontend/src/app/shared/breadcrumb.component.ts
+++ b/frontend/src/app/shared/breadcrumb.component.ts
@@ -14,14 +14,14 @@ export interface Crumb {
   imports: [NgForOf, NgIf, RouterLink, TranslateModule],
   template: `
     <nav aria-label="Breadcrumb">
-      <ol class="flex flex-wrap items-center gap-2 text-sm text-slate-600">
+      <ol class="flex flex-wrap items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
         <li *ngFor="let crumb of crumbs; let last = last" class="flex items-center gap-2">
           <ng-container *ngIf="crumb.url && !last; else lastCrumb">
-            <a [routerLink]="crumb.url" class="hover:text-slate-900 font-medium">{{ crumb.label | translate }}</a>
-            <span aria-hidden="true" class="text-slate-400">/</span>
+            <a [routerLink]="crumb.url" class="hover:text-slate-900 font-medium dark:hover:text-white">{{ crumb.label | translate }}</a>
+            <span aria-hidden="true" class="text-slate-400 dark:text-slate-500">/</span>
           </ng-container>
           <ng-template #lastCrumb>
-            <span class="font-semibold text-slate-900">{{ crumb.label | translate }}</span>
+            <span class="font-semibold text-slate-900 dark:text-slate-50">{{ crumb.label | translate }}</span>
           </ng-template>
         </li>
       </ol>

--- a/frontend/src/app/shared/card.component.ts
+++ b/frontend/src/app/shared/card.component.ts
@@ -4,8 +4,8 @@ import { Component, Input } from '@angular/core';
   selector: 'app-card',
   standalone: true,
   template: `
-    <div class="rounded-2xl border border-slate-200 bg-white shadow-sm p-4 md:p-6">
-      <div *ngIf="title" class="text-base font-semibold text-slate-900 mb-2">{{ title }}</div>
+    <div class="rounded-2xl border border-slate-200 bg-white shadow-sm p-4 md:p-6 text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:shadow-none">
+      <div *ngIf="title" class="text-base font-semibold text-slate-900 dark:text-slate-50 mb-2">{{ title }}</div>
       <ng-content></ng-content>
     </div>
   `

--- a/frontend/src/app/shared/modal.component.ts
+++ b/frontend/src/app/shared/modal.component.ts
@@ -12,17 +12,17 @@ import { ButtonComponent } from './button.component';
         #dialogRef
         role="dialog"
         aria-modal="true"
-        class="w-full max-w-lg rounded-2xl bg-white shadow-xl border border-slate-200 p-6 grid gap-4 outline-none"
+        class="w-full max-w-lg rounded-2xl bg-white shadow-xl border border-slate-200 p-6 grid gap-4 outline-none dark:bg-slate-900 dark:border-slate-700 dark:shadow-none"
         tabindex="-1"
       >
         <div class="flex items-start justify-between gap-4">
           <div class="grid gap-1">
-            <div class="text-lg font-semibold text-slate-900">{{ title }}</div>
-            <div class="text-slate-600 text-sm" *ngIf="subtitle">{{ subtitle }}</div>
+            <div class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ title }}</div>
+            <div class="text-slate-600 text-sm dark:text-slate-300" *ngIf="subtitle">{{ subtitle }}</div>
           </div>
           <app-button variant="ghost" size="sm" label="Close" (action)="close()"></app-button>
         </div>
-        <div class="text-sm text-slate-700">
+        <div class="text-sm text-slate-700 dark:text-slate-200">
           <ng-content></ng-content>
         </div>
         <div class="flex justify-end gap-3" *ngIf="showActions">

--- a/frontend/src/app/shared/toast.component.ts
+++ b/frontend/src/app/shared/toast.component.ts
@@ -13,7 +13,7 @@ export interface ToastMessage {
   standalone: true,
   imports: [NgForOf],
   template: `
-    <div class="fixed inset-x-0 top-4 z-50 flex flex-col items-center gap-3 px-4">
+    <div class="pointer-events-none fixed inset-x-0 top-4 z-50 flex flex-col items-center gap-3 px-4">
       <div
         *ngFor="let toast of messages"
         class="w-full max-w-md rounded-xl border border-slate-200 bg-white shadow-lg px-4 py-3 grid gap-1 dark:bg-slate-900 dark:border-slate-700 dark:shadow-none"

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -27,7 +27,11 @@ video {
 }
 
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
+}
+
+:root.dark {
+  color-scheme: dark;
 }
 
 *:focus-visible {

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: ["./src/**/*.{html,ts}"],
   theme: {
     extend: {


### PR DESCRIPTION
- **Summary**
  - Fixes theme switching so Light/Dark/System works regardless of OS theme, and improves readability/interaction in both themes.

- **Changes**
  - Configure Tailwind to use class-based dark mode and sync `color-scheme` to the active theme.
  - Improve dark-mode contrast across key pages/components (home/shop/product/cart/checkout/account/admin/auth/error).
  - Make toast notifications non-blocking and dedupe identical messages.
  - Style Stripe CardElement for dark mode and update styles on theme changes (checkout + account).

- **Testing**
  - `cd frontend && npm run lint` (pass; warnings only)
  - `cd frontend && npm run build` (pass; bundle budget warnings)

- **Risk & Impact**
  - Tailwind dark mode behavior changes from media to class; relies on `ThemeService` toggling the `dark` class.
  - UI styling changes across many templates; mainly class updates.

- **Related TODO items**
  - [x] Fix theme switching to override system (Tailwind `darkMode: 'class'`) and sync `color-scheme` to match selected theme.
  - [x] UX: prevent toast notifications from blocking interactions and dedupe repeated error toasts.
  - [x] UX: make Stripe CardElement readable in dark mode and update styles on theme changes (checkout + account).
  - [x] Perf: fix account idle-timer event listener cleanup (avoid leaking listeners with `.bind(this)`).