### PR TITLE
fix: render shared buttons and Google OAuth CTA

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -168,6 +168,7 @@ Below is a structured checklist you can turn into issues.
 - [x] Tailwind CSS and design tokens.
 - [x] Main layout (header/footer/responsive nav).
 - [x] Shared components: button, input, card, modal, toast.
+- [x] Fix shared standalone components missing `NgIf` imports so buttons/labels render correctly.
 - [x] Global error handling / boundary route.
 - [x] API service layer + interceptors.
 - [x] Theme tokens (spacing, typography, colors).

--- a/frontend/src/app/shared/button.component.ts
+++ b/frontend/src/app/shared/button.component.ts
@@ -1,14 +1,15 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { NgClass } from '@angular/common';
+import { NgClass, NgIf } from '@angular/common';
 import { RouterLink } from '@angular/router';
 
 type ButtonVariant = 'primary' | 'ghost';
 type ButtonSize = 'md' | 'sm';
+type ButtonType = 'button' | 'submit' | 'reset';
 
 @Component({
   selector: 'app-button',
   standalone: true,
-  imports: [NgClass, RouterLink],
+  imports: [NgIf, NgClass, RouterLink],
   template: `
     <ng-container *ngIf="routerLink; else buttonTpl">
       <a
@@ -22,11 +23,11 @@ type ButtonSize = 'md' | 'sm';
     </ng-container>
     <ng-template #buttonTpl>
       <button
-        type="button"
+        [attr.type]="type"
         [ngClass]="classes"
         class="inline-flex items-center justify-center rounded-full font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
         [disabled]="disabled"
-        (click)="!disabled && action.emit()"
+        (click)="onClick($event)"
       >
         <ng-content></ng-content>
         <span *ngIf="label">{{ label }}</span>
@@ -38,6 +39,7 @@ export class ButtonComponent {
   @Input() label = '';
   @Input() variant: ButtonVariant = 'primary';
   @Input() size: ButtonSize = 'md';
+  @Input() type: ButtonType = 'button';
   @Input() routerLink?: string | any[];
   @Input() disabled = false;
   @Output() action = new EventEmitter<void>();
@@ -49,5 +51,17 @@ export class ButtonComponent {
     const sizeCls = this.size === 'sm' ? 'px-3 py-2 text-sm' : 'px-4 py-2.5 text-sm';
     const state = this.disabled ? 'opacity-60 cursor-not-allowed' : '';
     return `${base} ${sizeCls} ${state}`;
+  }
+
+  onClick(event: MouseEvent): void {
+    if (this.disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    if (this.type === 'button') {
+      this.action.emit();
+    }
   }
 }

--- a/frontend/src/app/shared/card.component.ts
+++ b/frontend/src/app/shared/card.component.ts
@@ -1,8 +1,10 @@
+import { NgIf } from '@angular/common';
 import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'app-card',
   standalone: true,
+  imports: [NgIf],
   template: `
     <div class="rounded-2xl border border-slate-200 bg-white shadow-sm p-4 md:p-6 text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:shadow-none">
       <div *ngIf="title" class="text-base font-semibold text-slate-900 dark:text-slate-50 mb-2">{{ title }}</div>

--- a/frontend/src/app/shared/input.component.ts
+++ b/frontend/src/app/shared/input.component.ts
@@ -1,11 +1,11 @@
 import { Component, Input } from '@angular/core';
-import { NgClass } from '@angular/common';
+import { NgClass, NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-input',
   standalone: true,
-  imports: [FormsModule, NgClass],
+  imports: [FormsModule, NgClass, NgIf],
   template: `
     <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
       <span *ngIf="label">{{ label }}</span>


### PR DESCRIPTION
**Summary**
- Fixes missing CTA buttons (including “Continue with Google”) by correcting standalone shared component imports.

**Changes**
- Frontend: add missing `NgIf` imports to `app-button`, `app-input`, and `app-card` so their templates render.
- Frontend: support `type="submit"`/`reset` on `app-button` and avoid emitting `(action)` for submit buttons.
- Backlog: record the fix in `TODO.md`.

**Testing**
- `cd frontend && npm run lint` (warnings only)
- `cd frontend && npm run build`

**Risk & Impact**
- Low risk; changes are isolated to shared UI components and improve form/button behavior.

**Related TODO items**
- [x] Fix shared standalone components missing `NgIf` imports so buttons/labels render correctly.