### PR TITLE
feat: polish footer/header and add About page

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -169,6 +169,9 @@ Below is a structured checklist you can turn into issues.
 - [x] Main layout (header/footer/responsive nav).
 - [x] Shared components: button, input, card, modal, toast.
 - [x] Fix shared standalone components missing `NgIf` imports so buttons/labels render correctly.
+- [x] Header: improve theme/language control layout and add a global product search field.
+- [x] Footer: remove year suffix from tagline and replace Pinterest link with Facebook.
+- [x] Frontend: add `/about` route rendering CMS `page.about` content.
 - [x] Global error handling / boundary route.
 - [x] API service layer + interceptors.
 - [x] Theme tokens (spacing, typography, colors).
@@ -193,6 +196,7 @@ Below is a structured checklist you can turn into issues.
 - [x] Featured products grid on homepage.
 - [x] Category listing with grid + pagination.
 - [x] Filter sidebar (category, price range, tags).
+- [x] Shop: fix filter sidebar price slider overflow.
 - [x] Search bar hitting /products.
 - [x] Product card component (image, name, price, stock badge).
 - [x] Product detail page with gallery, variants, quantity/add-to-cart.

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { HomeComponent } from './pages/home/home.component';
 import { NotFoundComponent } from './pages/not-found/not-found.component';
 import { ErrorComponent } from './pages/error/error.component';
 import { ShopComponent } from './pages/shop/shop.component';
+import { AboutComponent } from './pages/about/about.component';
 import { ProductComponent } from './pages/product/product.component';
 import { AdminComponent } from './pages/admin/admin.component';
 import { authGuard, adminGuard } from './core/auth.guard';
@@ -21,6 +22,7 @@ import { shopCategoriesResolver } from './core/shop.resolver';
 export const routes: Routes = [
   { path: '', component: HomeComponent, title: 'AdrianaArt' },
   { path: 'shop', component: ShopComponent, title: 'Shop | AdrianaArt', resolve: { categories: shopCategoriesResolver } },
+  { path: 'about', component: AboutComponent, title: 'About | AdrianaArt' },
   { path: 'products/:slug', component: ProductComponent, title: 'Product | AdrianaArt' },
   { path: 'cart', component: CartComponent, title: 'Cart | AdrianaArt' },
   { path: 'checkout', component: CheckoutComponent, title: 'Checkout | AdrianaArt' },

--- a/frontend/src/app/layout/footer.component.ts
+++ b/frontend/src/app/layout/footer.component.ts
@@ -12,7 +12,7 @@ import { TranslateModule } from '@ngx-translate/core';
         <p class="text-slate-500 dark:text-slate-400">{{ 'footer.tagline' | translate }}</p>
         <div class="flex gap-4">
           <a class="hover:text-slate-900 dark:hover:text-white" href="#">{{ 'footer.instagram' | translate }}</a>
-          <a class="hover:text-slate-900 dark:hover:text-white" href="#">{{ 'footer.pinterest' | translate }}</a>
+          <a class="hover:text-slate-900 dark:hover:text-white" href="#">{{ 'footer.facebook' | translate }}</a>
           <a class="hover:text-slate-900 dark:hover:text-white" href="#">{{ 'footer.contact' | translate }}</a>
         </div>
       </div>

--- a/frontend/src/app/layout/header.component.ts
+++ b/frontend/src/app/layout/header.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '../shared/button.component';
 import { NavDrawerComponent, NavLink } from '../shared/nav-drawer.component';
 import { NgIf, NgForOf } from '@angular/common';
@@ -24,6 +24,24 @@ import { TranslateModule } from '@ngx-translate/core';
           <a routerLink="/shop" class="hover:text-slate-900 dark:hover:text-white">{{ 'nav.shop' | translate }}</a>
           <a routerLink="/about" class="hover:text-slate-900 dark:hover:text-white">{{ 'nav.about' | translate }}</a>
         </nav>
+        <form class="hidden md:flex flex-1 justify-center" (submit)="submitSearch($event)">
+          <div class="relative w-full max-w-md">
+            <input
+              name="q"
+              type="search"
+              class="w-full h-10 rounded-full border border-slate-200 bg-white px-4 pr-10 text-sm text-slate-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500/40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
+              [placeholder]="'shop.searchPlaceholder' | translate"
+              [(ngModel)]="searchQuery"
+            />
+            <button
+              type="submit"
+              class="absolute right-2 top-1/2 -translate-y-1/2 h-8 w-8 grid place-items-center rounded-full text-slate-500 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white"
+              aria-label="Search"
+            >
+              🔎
+            </button>
+          </div>
+        </form>
         <div class="flex items-center gap-3">
           <button
             type="button"
@@ -50,25 +68,42 @@ import { TranslateModule } from '@ngx-translate/core';
           <a routerLink="/login" class="text-sm font-medium text-slate-700 hover:text-slate-900 hidden sm:inline dark:text-slate-200 dark:hover:text-white">
             {{ 'nav.signIn' | translate }}
           </a>
-          <label class="hidden sm:flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
-            <span class="sr-only">Theme</span>
-            <select
-              class="rounded-full border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
-              [ngModel]="themePreference"
-              (ngModelChange)="onThemeChange($event)"
-            >
-              <option value="system">System</option>
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
-            </select>
-          </label>
+          <div class="hidden sm:flex items-center gap-2 rounded-full border border-slate-200 bg-white/70 px-2 py-1 shadow-sm dark:border-slate-700 dark:bg-slate-800/70">
+            <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+              <span class="sr-only">Theme</span>
+              <select
+                class="h-9 rounded-full bg-transparent px-2 text-sm text-slate-900 focus:outline-none dark:text-slate-100"
+                [ngModel]="themePreference"
+                (ngModelChange)="onThemeChange($event)"
+                aria-label="Theme"
+              >
+                <option value="system">System</option>
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+              </select>
+            </label>
+            <div class="h-6 w-px bg-slate-200 dark:bg-slate-700"></div>
+            <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+              <span class="sr-only">Language</span>
+              <select
+                class="h-9 rounded-full bg-transparent px-2 text-sm text-slate-900 focus:outline-none dark:text-slate-100"
+                [ngModel]="language"
+                (ngModelChange)="onLanguageChange($event)"
+                aria-label="Language"
+              >
+                <option value="en">EN</option>
+                <option value="ro">RO</option>
+              </select>
+            </label>
+          </div>
           <app-button label="Theme" size="sm" variant="ghost" class="sm:hidden" (action)="cycleTheme()"></app-button>
-          <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+          <label class="sm:hidden flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
             <span class="sr-only">Language</span>
             <select
-              class="rounded-full border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              class="h-10 rounded-full border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
               [ngModel]="language"
               (ngModelChange)="onLanguageChange($event)"
+              aria-label="Language"
             >
               <option value="en">EN</option>
               <option value="ro">RO</option>
@@ -86,6 +121,7 @@ export class HeaderComponent {
   @Input() language = 'en';
   @Output() languageChange = new EventEmitter<string>();
   drawerOpen = false;
+  searchQuery = '';
   navLinks: NavLink[] = [
     { label: 'nav.home', path: '/' },
     { label: 'nav.shop', path: '/shop' },
@@ -93,7 +129,7 @@ export class HeaderComponent {
     { label: 'nav.admin', path: '/admin' }
   ];
 
-  constructor(private cart: CartStore) {}
+  constructor(private cart: CartStore, private router: Router) {}
 
   cartCount = this.cart.count;
 
@@ -113,5 +149,11 @@ export class HeaderComponent {
 
   onLanguageChange(lang: string): void {
     this.languageChange.emit(lang);
+  }
+
+  submitSearch(event: Event): void {
+    event.preventDefault();
+    const q = this.searchQuery.trim();
+    void this.router.navigate(['/shop'], { queryParams: q ? { q } : {} });
   }
 }

--- a/frontend/src/app/pages/about/about.component.ts
+++ b/frontend/src/app/pages/about/about.component.ts
@@ -1,0 +1,111 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { Meta, Title } from '@angular/platform-browser';
+import { Subscription } from 'rxjs';
+import { ApiService } from '../../core/api.service';
+import { ContainerComponent } from '../../layout/container.component';
+import { BreadcrumbComponent } from '../../shared/breadcrumb.component';
+import { CardComponent } from '../../shared/card.component';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+
+interface ContentImage {
+  url: string;
+  alt_text?: string | null;
+}
+
+interface ContentBlock {
+  title: string;
+  body_markdown: string;
+  images: ContentImage[];
+}
+
+@Component({
+  selector: 'app-about',
+  standalone: true,
+  imports: [CommonModule, ContainerComponent, BreadcrumbComponent, CardComponent, TranslateModule],
+  template: `
+    <app-container classes="py-10 grid gap-6 max-w-3xl">
+      <app-breadcrumb [crumbs]="crumbs"></app-breadcrumb>
+      <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-50">{{ block()?.title || ('nav.about' | translate) }}</h1>
+
+      <app-card>
+        <div *ngIf="loading()" class="text-sm text-slate-600 dark:text-slate-300">
+          {{ 'about.loading' | translate }}
+        </div>
+
+        <div *ngIf="!loading() && hasError()" class="grid gap-2">
+          <p class="font-semibold text-amber-900 dark:text-amber-100">{{ 'about.errorTitle' | translate }}</p>
+          <p class="text-sm text-amber-800 dark:text-amber-200">{{ 'about.errorCopy' | translate }}</p>
+        </div>
+
+        <div *ngIf="!loading() && !hasError() && block()" class="grid gap-5">
+          <img
+            *ngIf="block()!.images?.length"
+            [src]="block()!.images[0].url"
+            [alt]="block()!.images[0].alt_text || block()!.title"
+            class="w-full rounded-2xl border border-slate-200 bg-slate-50 object-cover dark:border-slate-800 dark:bg-slate-800"
+            loading="lazy"
+          />
+          <div class="text-slate-700 leading-relaxed whitespace-pre-line dark:text-slate-200">
+            {{ block()!.body_markdown }}
+          </div>
+        </div>
+      </app-card>
+    </app-container>
+  `
+})
+export class AboutComponent implements OnInit, OnDestroy {
+  crumbs = [
+    { label: 'nav.home', url: '/' },
+    { label: 'nav.about' }
+  ];
+
+  block = signal<ContentBlock | null>(null);
+  loading = signal<boolean>(true);
+  hasError = signal<boolean>(false);
+
+  private langSub?: Subscription;
+
+  constructor(private api: ApiService, private translate: TranslateService, private title: Title, private meta: Meta) {}
+
+  ngOnInit(): void {
+    this.load();
+    this.langSub = this.translate.onLangChange.subscribe(() => this.load());
+  }
+
+  ngOnDestroy(): void {
+    this.langSub?.unsubscribe();
+  }
+
+  private load(): void {
+    this.loading.set(true);
+    this.hasError.set(false);
+    const lang = this.translate.currentLang === 'ro' ? 'ro' : 'en';
+    this.api.get<ContentBlock>('/content/pages/about', { lang }).subscribe({
+      next: (block) => {
+        this.block.set(block);
+        this.loading.set(false);
+        this.hasError.set(false);
+        this.setMetaTags(block.title, block.body_markdown);
+      },
+      error: () => {
+        this.block.set(null);
+        this.loading.set(false);
+        this.hasError.set(true);
+        this.setMetaTags(this.translate.instant('about.metaTitle'), this.translate.instant('about.metaDescription'));
+      }
+    });
+  }
+
+  private setMetaTags(title: string, body: string): void {
+    const pageTitle = title ? `${title} | AdrianaArt` : 'About | AdrianaArt';
+    const description = (body || '').replace(/\s+/g, ' ').trim().slice(0, 160);
+    this.title.setTitle(pageTitle);
+    if (description) {
+      this.meta.updateTag({ name: 'description', content: description });
+      this.meta.updateTag({ name: 'og:description', content: description });
+    }
+    this.meta.updateTag({ name: 'og:title', content: pageTitle });
+  }
+}
+

--- a/frontend/src/app/pages/shop/shop.component.ts
+++ b/frontend/src/app/pages/shop/shop.component.ts
@@ -85,8 +85,26 @@ import { Meta, Title } from '@angular/platform-browser';
             <p class="text-sm font-semibold text-slate-800 dark:text-slate-200">{{ 'shop.priceRange' | translate }}</p>
             <div class="grid gap-3">
               <div class="flex items-center gap-3">
-                <input type="range" min="0" max="500" step="5" [(ngModel)]="filters.min_price" (change)="applyFilters()" aria-label="Minimum price" />
-                <input type="range" min="0" max="500" step="5" [(ngModel)]="filters.max_price" (change)="applyFilters()" aria-label="Maximum price" />
+                <input
+                  type="range"
+                  min="0"
+                  max="500"
+                  step="5"
+                  class="min-w-0 flex-1"
+                  [(ngModel)]="filters.min_price"
+                  (change)="applyFilters()"
+                  aria-label="Minimum price"
+                />
+                <input
+                  type="range"
+                  min="0"
+                  max="500"
+                  step="5"
+                  class="min-w-0 flex-1"
+                  [(ngModel)]="filters.max_price"
+                  (change)="applyFilters()"
+                  aria-label="Maximum price"
+                />
               </div>
               <div class="grid grid-cols-2 gap-3">
                 <app-input [label]="'shop.min' | translate" type="number" [(value)]="filters.min_price" (ngModelChange)="applyFilters()">

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -13,10 +13,17 @@
     "menu": "Menu"
   },
   "footer": {
-    "tagline": "Handcrafted ceramics · Since 2024",
+    "tagline": "Handcrafted ceramics",
     "instagram": "Instagram",
-    "pinterest": "Pinterest",
+    "facebook": "Facebook",
     "contact": "Contact"
+  },
+  "about": {
+    "loading": "Loading about page…",
+    "errorTitle": "Could not load About content.",
+    "errorCopy": "Please try again in a moment.",
+    "metaTitle": "About AdrianaArt",
+    "metaDescription": "Learn about AdrianaArt and the story behind our handcrafted ceramics."
   },
   "home": {
     "headline": "Build the AdrianaArt storefront experience.",

--- a/frontend/src/assets/i18n/ro.json
+++ b/frontend/src/assets/i18n/ro.json
@@ -13,10 +13,17 @@
     "menu": "Meniu"
   },
   "footer": {
-    "tagline": "Ceramică realizată manual · Din 2024",
+    "tagline": "Ceramică realizată manual",
     "instagram": "Instagram",
-    "pinterest": "Pinterest",
+    "facebook": "Facebook",
     "contact": "Contact"
+  },
+  "about": {
+    "loading": "Se încarcă pagina Despre…",
+    "errorTitle": "Nu am putut încărca pagina Despre.",
+    "errorCopy": "Încearcă din nou în câteva momente.",
+    "metaTitle": "Despre AdrianaArt",
+    "metaDescription": "Află povestea AdrianaArt și detalii despre ceramica noastră realizată manual."
   },
   "home": {
     "headline": "Construiește experiența magazinului AdrianaArt.",


### PR DESCRIPTION
**Summary**
- Polishes key storefront UX: footer copy/social links, header controls + global search, shop filter layout, and adds a real `/about` page.

**Changes**
- Footer: remove the “· Since 2024 / Din 2024” suffix and replace Pinterest with Facebook.
- Header: group theme/language controls for better layout and add a global product search that navigates to `/shop?q=...`.
- Shop: fix price range sliders overflowing the filter sidebar.
- About: add `/about` route and page that renders CMS `page.about` content (localized via `lang`).
- i18n: update `footer.*` labels and add `about.*` loading/error/meta copy.

**Testing**
- `cd frontend && npm run lint` (warnings only)
- `cd frontend && npm run build`

**Risk & Impact**
- Low; UI-only changes plus a new route. Header search updates URL query params for shop.

**Related TODO items**
- [x] Header: improve theme/language control layout and add a global product search field.
- [x] Footer: remove year suffix from tagline and replace Pinterest link with Facebook.
- [x] Frontend: add `/about` route rendering CMS `page.about` content.
- [x] Shop: fix filter sidebar price slider overflow.