### PR TITLE
fix: improve header controls and shop filters

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -172,6 +172,8 @@ Below is a structured checklist you can turn into issues.
 - [x] Header: improve theme/language control layout and add a global product search field.
 - [x] Footer: remove year suffix from tagline and replace Pinterest link with Facebook.
 - [x] Frontend: add `/about` route rendering CMS `page.about` content.
+- [x] Header: make theme/language dropdown options readable in dark mode.
+- [x] Header: avoid search/nav overlap on medium screens (use nav drawer + show search on wide screens).
 - [x] Global error handling / boundary route.
 - [x] API service layer + interceptors.
 - [x] Theme tokens (spacing, typography, colors).

--- a/frontend/src/app/layout/header.component.ts
+++ b/frontend/src/app/layout/header.component.ts
@@ -19,12 +19,12 @@ import { TranslateModule } from '@ngx-translate/core';
           <span class="h-10 w-10 rounded-full bg-slate-900 text-white grid place-items-center font-bold dark:bg-slate-50 dark:text-slate-900">AA</span>
           <span>{{ 'app.name' | translate }}</span>
         </a>
-        <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <nav class="hidden lg:flex items-center gap-6 text-sm font-medium text-slate-700 dark:text-slate-200">
           <a routerLink="/" class="hover:text-slate-900 dark:hover:text-white">{{ 'nav.home' | translate }}</a>
           <a routerLink="/shop" class="hover:text-slate-900 dark:hover:text-white">{{ 'nav.shop' | translate }}</a>
           <a routerLink="/about" class="hover:text-slate-900 dark:hover:text-white">{{ 'nav.about' | translate }}</a>
         </nav>
-        <form class="hidden md:flex flex-1 justify-center" (submit)="submitSearch($event)">
+        <form class="hidden xl:flex flex-1 justify-center" (submit)="submitSearch($event)">
           <div class="relative w-full max-w-md">
             <input
               name="q"
@@ -45,7 +45,7 @@ import { TranslateModule } from '@ngx-translate/core';
         <div class="flex items-center gap-3">
           <button
             type="button"
-            class="md:hidden text-slate-700 hover:text-slate-900 dark:text-slate-200 dark:hover:text-white"
+            class="lg:hidden text-slate-700 hover:text-slate-900 dark:text-slate-200 dark:hover:text-white"
             (click)="toggleDrawer()"
             aria-label="Open navigation"
             [attr.aria-expanded]="drawerOpen"

--- a/frontend/src/app/pages/shop/shop.component.ts
+++ b/frontend/src/app/pages/shop/shop.component.ts
@@ -85,26 +85,30 @@ import { Meta, Title } from '@angular/platform-browser';
             <p class="text-sm font-semibold text-slate-800 dark:text-slate-200">{{ 'shop.priceRange' | translate }}</p>
             <div class="grid gap-3">
               <div class="flex items-center gap-3">
-                <input
-                  type="range"
-                  min="0"
-                  max="500"
-                  step="5"
-                  class="min-w-0 flex-1"
-                  [(ngModel)]="filters.min_price"
-                  (change)="applyFilters()"
-                  aria-label="Minimum price"
-                />
-                <input
-                  type="range"
-                  min="0"
-                  max="500"
-                  step="5"
-                  class="min-w-0 flex-1"
-                  [(ngModel)]="filters.max_price"
-                  (change)="applyFilters()"
-                  aria-label="Maximum price"
-                />
+                <div class="min-w-0 flex-1">
+                  <input
+                    type="range"
+                    min="0"
+                    max="500"
+                    step="5"
+                    class="w-full"
+                    [(ngModel)]="filters.min_price"
+                    (change)="applyFilters()"
+                    aria-label="Minimum price"
+                  />
+                </div>
+                <div class="min-w-0 flex-1">
+                  <input
+                    type="range"
+                    min="0"
+                    max="500"
+                    step="5"
+                    class="w-full"
+                    [(ngModel)]="filters.max_price"
+                    (change)="applyFilters()"
+                    aria-label="Maximum price"
+                  />
+                </div>
               </div>
               <div class="grid grid-cols-2 gap-3">
                 <app-input [label]="'shop.min' | translate" type="number" [(value)]="filters.min_price" (ngModelChange)="applyFilters()">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -34,6 +34,16 @@ video {
   color-scheme: dark;
 }
 
+:root select option {
+  background-color: #ffffff;
+  color: #0f172a;
+}
+
+:root.dark select option {
+  background-color: #1e293b;
+  color: #f8fafc;
+}
+
 *:focus-visible {
   outline: 2px solid #6366f1;
   outline-offset: 2px;


### PR DESCRIPTION
**Summary**
- Fixes header dropdown usability in dark mode, prevents header layout collisions at medium widths, and fully constrains shop price sliders.

**Changes**
- Header: move top nav to `lg+` and search field to `xl+` so controls don’t overlap on smaller screens (nav drawer used instead).
- Header: add CSS to style native `<select><option>` backgrounds/foregrounds for dark mode so dropdown items are readable.
- Shop: wrap price range sliders and set `w-full` so they don’t overflow the filter sidebar.
- Backlog: mark these UX fixes as completed in `TODO.md`.

**Testing**
- `cd frontend && npm run lint` (warnings only)
- `cd frontend && npm run build`

**Risk & Impact**
- Low; CSS + template tweaks only. Header search is now shown on wide screens; shop search remains available on the Shop page.

**Related TODO items**
- [x] Header: make theme/language dropdown options readable in dark mode.
- [x] Header: avoid search/nav overlap on medium screens (use nav drawer + show search on wide screens).
- [x] Shop: fix filter sidebar price slider overflow.