### PR TITLE
fix: stabilize theme UX and shop filters

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -198,7 +198,7 @@ Below is a structured checklist you can turn into issues.
 - [x] Featured products grid on homepage.
 - [x] Category listing with grid + pagination.
 - [x] Filter sidebar (category, price range, tags).
-- [x] Shop: fix filter sidebar price slider overflow.
+- [x] Shop: prevent price range sliders overflowing the sidebar (stack vertically).
 - [x] Search bar hitting /products.
 - [x] Product card component (image, name, price, stock badge).
 - [x] Product detail page with gallery, variants, quantity/add-to-cart.
@@ -402,8 +402,8 @@ Below is a structured checklist you can turn into issues.
 - [x] UX: prevent toast notifications from blocking interactions and dedupe repeated error toasts.
 - [x] UX: make Stripe CardElement readable in dark mode and update styles on theme changes (checkout + account).
 - [x] Perf: fix account idle-timer event listener cleanup (avoid leaking listeners with `.bind(this)`).
-- [ ] Follow-up: set `<meta name="theme-color">` dynamically based on selected theme (mobile address bar).
-- [ ] Follow-up: add early theme bootstrap in `frontend/src/index.html` to avoid flash of incorrect theme on load.
+- [x] Follow-up: set `<meta name="theme-color">` dynamically based on selected theme (mobile address bar).
+- [x] Follow-up: add early theme bootstrap in `frontend/src/index.html` to avoid flash of incorrect theme on load.
 
 ## Backlog (New ideas inspired by Event Link)
 

--- a/frontend/src/app/core/theme.service.ts
+++ b/frontend/src/app/core/theme.service.ts
@@ -57,6 +57,24 @@ export class ThemeService {
     this.modeSignal.set(mode);
     if (typeof document !== 'undefined') {
       document.documentElement.classList.toggle('dark', mode === 'dark');
+      document.documentElement.style.colorScheme = mode;
+
+      const overrideId = 'theme-color-override';
+      const existing = document.getElementById(overrideId) as HTMLMetaElement | null;
+      const preference = this.preferenceSignal();
+      if (preference === 'system') {
+        existing?.remove();
+        return;
+      }
+
+      const color = mode === 'dark' ? '#0f172a' : '#f8fafc';
+      const meta = existing ?? document.createElement('meta');
+      meta.id = overrideId;
+      meta.name = 'theme-color';
+      meta.content = color;
+      if (!existing) {
+        document.head.appendChild(meta);
+      }
     }
   }
 

--- a/frontend/src/app/layout/header.component.ts
+++ b/frontend/src/app/layout/header.component.ts
@@ -14,7 +14,7 @@ import { TranslateModule } from '@ngx-translate/core';
   imports: [RouterLink, ButtonComponent, NavDrawerComponent, NgIf, NgForOf, FormsModule, TranslateModule],
   template: `
     <header class="border-b border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
-      <div class="max-w-6xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between gap-6">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between gap-6">
         <a routerLink="/" class="flex items-center gap-2 text-lg font-semibold tracking-tight text-slate-900 dark:text-slate-50">
           <span class="h-10 w-10 rounded-full bg-slate-900 text-white grid place-items-center font-bold dark:bg-slate-50 dark:text-slate-900">AA</span>
           <span>{{ 'app.name' | translate }}</span>
@@ -24,8 +24,8 @@ import { TranslateModule } from '@ngx-translate/core';
           <a routerLink="/shop" class="hover:text-slate-900 dark:hover:text-white">{{ 'nav.shop' | translate }}</a>
           <a routerLink="/about" class="hover:text-slate-900 dark:hover:text-white">{{ 'nav.about' | translate }}</a>
         </nav>
-        <form class="hidden xl:flex flex-1 justify-center" (submit)="submitSearch($event)">
-          <div class="relative w-full max-w-md">
+        <form class="hidden xl:flex flex-1 min-w-0 justify-center" (submit)="submitSearch($event)">
+          <div class="relative w-full max-w-sm min-w-0">
             <input
               name="q"
               type="search"
@@ -72,27 +72,27 @@ import { TranslateModule } from '@ngx-translate/core';
             <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
               <span class="sr-only">Theme</span>
               <select
-                class="h-9 rounded-full bg-transparent px-2 text-sm text-slate-900 focus:outline-none dark:text-slate-100"
+                class="h-9 rounded-full bg-transparent px-2 text-sm text-slate-900 focus:outline-none [color-scheme:light] dark:text-slate-100 dark:[color-scheme:dark]"
                 [ngModel]="themePreference"
                 (ngModelChange)="onThemeChange($event)"
                 aria-label="Theme"
               >
-                <option value="system">System</option>
-                <option value="light">Light</option>
-                <option value="dark">Dark</option>
+                <option class="bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100" value="system">System</option>
+                <option class="bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100" value="light">Light</option>
+                <option class="bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100" value="dark">Dark</option>
               </select>
             </label>
             <div class="h-6 w-px bg-slate-200 dark:bg-slate-700"></div>
             <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
               <span class="sr-only">Language</span>
               <select
-                class="h-9 rounded-full bg-transparent px-2 text-sm text-slate-900 focus:outline-none dark:text-slate-100"
+                class="h-9 rounded-full bg-transparent px-2 text-sm text-slate-900 focus:outline-none [color-scheme:light] dark:text-slate-100 dark:[color-scheme:dark]"
                 [ngModel]="language"
                 (ngModelChange)="onLanguageChange($event)"
                 aria-label="Language"
               >
-                <option value="en">EN</option>
-                <option value="ro">RO</option>
+                <option class="bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100" value="en">EN</option>
+                <option class="bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100" value="ro">RO</option>
               </select>
             </label>
           </div>
@@ -100,13 +100,13 @@ import { TranslateModule } from '@ngx-translate/core';
           <label class="sm:hidden flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
             <span class="sr-only">Language</span>
             <select
-              class="h-10 rounded-full border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              class="h-10 rounded-full border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:outline-none [color-scheme:light] dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:[color-scheme:dark]"
               [ngModel]="language"
               (ngModelChange)="onLanguageChange($event)"
               aria-label="Language"
             >
-              <option value="en">EN</option>
-              <option value="ro">RO</option>
+              <option class="bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100" value="en">EN</option>
+              <option class="bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100" value="ro">RO</option>
             </select>
           </label>
         </div>

--- a/frontend/src/app/pages/shop/shop.component.ts
+++ b/frontend/src/app/pages/shop/shop.component.ts
@@ -84,31 +84,27 @@ import { Meta, Title } from '@angular/platform-browser';
           <div class="space-y-3">
             <p class="text-sm font-semibold text-slate-800 dark:text-slate-200">{{ 'shop.priceRange' | translate }}</p>
             <div class="grid gap-3">
-              <div class="flex items-center gap-3">
-                <div class="min-w-0 flex-1">
-                  <input
-                    type="range"
-                    min="0"
-                    max="500"
-                    step="5"
-                    class="w-full"
-                    [(ngModel)]="filters.min_price"
-                    (change)="applyFilters()"
-                    aria-label="Minimum price"
-                  />
-                </div>
-                <div class="min-w-0 flex-1">
-                  <input
-                    type="range"
-                    min="0"
-                    max="500"
-                    step="5"
-                    class="w-full"
-                    [(ngModel)]="filters.max_price"
-                    (change)="applyFilters()"
-                    aria-label="Maximum price"
-                  />
-                </div>
+              <div class="grid gap-2">
+                <input
+                  type="range"
+                  min="0"
+                  max="500"
+                  step="5"
+                  class="w-full accent-indigo-600"
+                  [(ngModel)]="filters.min_price"
+                  (change)="applyFilters()"
+                  aria-label="Minimum price"
+                />
+                <input
+                  type="range"
+                  min="0"
+                  max="500"
+                  step="5"
+                  class="w-full accent-indigo-600"
+                  [(ngModel)]="filters.max_price"
+                  (change)="applyFilters()"
+                  aria-label="Maximum price"
+                />
               </div>
               <div class="grid grid-cols-2 gap-3">
                 <app-input [label]="'shop.min' | translate" type="number" [(value)]="filters.min_price" (ngModelChange)="applyFilters()">

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -3,6 +3,34 @@
   <head>
     <meta charset="utf-8" />
     <script src="assets/app-config.js"></script>
+    <script>
+      (function () {
+        try {
+          const pref = localStorage.getItem('theme');
+          const hasMatchMedia = typeof window !== 'undefined' && 'matchMedia' in window;
+          const prefersDark = hasMatchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+          const mode = pref === 'dark' || pref === 'light' ? pref : prefersDark ? 'dark' : 'light';
+
+          document.documentElement.classList.toggle('dark', mode === 'dark');
+          document.documentElement.style.colorScheme = mode;
+
+          if (pref === 'dark' || pref === 'light') {
+            const color = mode === 'dark' ? '#0f172a' : '#f8fafc';
+            const overrideId = 'theme-color-override';
+            let meta = document.getElementById(overrideId);
+            if (!meta) {
+              meta = document.createElement('meta');
+              meta.setAttribute('id', overrideId);
+              meta.setAttribute('name', 'theme-color');
+              document.head.appendChild(meta);
+            }
+            meta.setAttribute('content', color);
+          }
+        } catch (err) {
+          // Ignore theme bootstrap errors (e.g. blocked storage).
+        }
+      })();
+    </script>
     <title>AdrianaArt Frontend</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +39,7 @@
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0f172a" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
-  <body class="bg-slate-50">
+  <body class="bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-50">
     <app-root></app-root>
   </body>
 </html>

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -8,8 +8,7 @@
   },
   "files": [
     "src/main.ts",
-    "src/app/app.config.ts",
-    "src/app/app.component.ts"
+    "src/polyfills.ts"
   ],
   "include": ["src/**/*.d.ts"]
 }


### PR DESCRIPTION
**Summary**
- Fixes a few frontend UX regressions: theme/language dropdown readability in dark mode, header search layout resilience, and shop price slider overflow.

**Changes**
- Theme: sync `color-scheme` with the selected theme and add a `theme-color` override meta for non-system preferences.
- Theme: add early theme bootstrap in `frontend/src/index.html` to avoid initial flash and keep native controls consistent.
- Header: widen layout slightly and tighten search sizing to avoid overlap on smaller wide screens.
- Shop: stack price range sliders vertically so they don’t overflow the filter sidebar.
- Build: restore a standard `frontend/tsconfig.app.json` entrypoint setup so new pages/components compile cleanly.

**Testing**
- `cd frontend && npm run lint` (warnings only)
- `cd frontend && npm run build` (warnings: bundle budgets)

**Risk & Impact**
- Low. Frontend-only changes. Theme meta override only applies when the user explicitly selects `light` or `dark`.

**Related TODO items**
- [x] Shop: prevent price range sliders overflowing the sidebar (stack vertically).
- [x] Follow-up: set `<meta name="theme-color">` dynamically based on selected theme (mobile address bar).
- [x] Follow-up: add early theme bootstrap in `frontend/src/index.html` to avoid flash of incorrect theme on load.
- [x] Header: make theme/language dropdown options readable in dark mode.
- [x] Header: avoid search/nav overlap on medium screens (use nav drawer + show search on wide screens).