### PR TITLE
fix: hide admin links and improve search UX

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -174,6 +174,8 @@ Below is a structured checklist you can turn into issues.
 - [x] Frontend: add `/about` route rendering CMS `page.about` content.
 - [x] Header: make theme/language dropdown options readable in dark mode.
 - [x] Header: avoid search/nav overlap on medium screens (use nav drawer + show search on wide screens).
+- [x] Header: keep product search accessible on windowed/small screens (show search at `lg`, provide a search overlay below `lg`).
+- [x] UI: hide admin CTA/nav items unless the signed-in user is an admin.
 - [x] Global error handling / boundary route.
 - [x] API service layer + interceptors.
 - [x] Theme tokens (spacing, typography, colors).

--- a/frontend/src/app/pages/home/home.component.ts
+++ b/frontend/src/app/pages/home/home.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, computed, signal } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { ButtonComponent } from '../../shared/button.component';
 import { CardComponent } from '../../shared/card.component';
@@ -10,6 +10,7 @@ import { ProductCardComponent } from '../../shared/product-card.component';
 import { SkeletonComponent } from '../../shared/skeleton.component';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { Meta, Title } from '@angular/platform-browser';
+import { AuthService } from '../../core/auth.service';
 
 @Component({
   selector: 'app-home',
@@ -26,7 +27,12 @@ import { Meta, Title } from '@angular/platform-browser';
           <p class="text-lg text-slate-600 dark:text-slate-300">{{ 'home.subhead' | translate }}</p>
           <div class="flex flex-wrap gap-3">
             <app-button [label]="'home.ctaShop' | translate" [routerLink]="['/shop']"></app-button>
-            <app-button [label]="'home.ctaAdmin' | translate" variant="ghost" [routerLink]="['/admin']"></app-button>
+            <app-button
+              *ngIf="isAdmin()"
+              [label]="'home.ctaAdmin' | translate"
+              variant="ghost"
+              [routerLink]="['/admin']"
+            ></app-button>
           </div>
         </div>
         <div class="relative">
@@ -102,6 +108,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   featuredLoading = signal<boolean>(true);
   featuredError = signal<boolean>(false);
   skeletons = Array.from({ length: 3 });
+  readonly isAdmin = computed(() => this.auth.role() === 'admin');
 
   private langSub?: Subscription;
 
@@ -110,7 +117,8 @@ export class HomeComponent implements OnInit, OnDestroy {
     private recentlyViewedService: RecentlyViewedService,
     private title: Title,
     private meta: Meta,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private auth: AuthService
   ) {}
 
   ngOnInit(): void {


### PR DESCRIPTION
**Summary**
- Fixes two storefront UX issues: global search availability on windowed/smaller screens and hiding admin navigation/CTA for non-admin users.

**Changes**
- Header: show the full search bar starting at `lg`, keep hamburger nav until `xl`, and add a small-screen search overlay (🔎) below `lg`.
- Header: only include the `/admin` nav link in the drawer when `auth.role() === 'admin'`.
- Home: hide the “View admin” CTA unless the signed-in user is an admin.
- TODO: add and mark completed the new UX tasks.

**Testing**
- `cd frontend && npm run lint` (warnings only)
- `cd frontend && npm run build` (warnings: bundle budgets)

**Risk & Impact**
- Low. UI-only change; admin routes remain protected by `adminGuard`.

**Related TODO items**
- [x] Header: keep product search accessible on windowed/small screens (show search at `lg`, provide a search overlay below `lg`).
- [x] UI: hide admin CTA/nav items unless the signed-in user is an admin.