### PR TITLE
feat: add blog metadata and filtering

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -231,8 +231,8 @@ Below is a structured checklist you can turn into issues.
 - [x] Media: add “insert image” action that uploads to `/content/admin/blog.{slug}/images` and inserts the URL into Markdown.
 - [x] SEO: add canonical link tags for blog list/post pages.
 - [x] SEO: include blog URLs in sitemap.xml and add OpenGraph meta per post.
-- [ ] Metadata: add summary, cover_image, tags, reading_time to ContentBlock.meta and show them in list/cards.
-- [ ] Filters: tag filter + search within blog posts (server-side).
+- [x] Metadata: add summary, cover_image, tags, reading_time to ContentBlock.meta and show them in list/cards.
+- [x] Filters: tag filter + search within blog posts (server-side).
 - [ ] Draft previews: shareable preview URL (token-based) for unpublished posts.
 - [ ] Scheduling: support publish_at / scheduled publishing and “unpublish”.
 - [ ] WYSIWYG upgrade (ProseMirror/Quill/etc.) with Markdown export/import.

--- a/backend/app/schemas/blog.py
+++ b/backend/app/schemas/blog.py
@@ -12,6 +12,8 @@ class BlogPostListItem(BaseModel):
     excerpt: str
     published_at: datetime | None = None
     cover_image_url: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    reading_time_minutes: int | None = None
 
 
 class BlogPostListResponse(BaseModel):
@@ -37,6 +39,10 @@ class BlogPostRead(BaseModel):
     updated_at: datetime
     images: list[BlogPostImage] = Field(default_factory=list)
     meta: dict | None = None
+    summary: str | None = None
+    cover_image_url: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    reading_time_minutes: int | None = None
 
 
 class BlogCommentAuthor(BaseModel):

--- a/backend/app/services/blog.py
+++ b/backend/app/services/blog.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+import re
 from datetime import datetime, timezone
 from uuid import UUID
 
@@ -14,6 +16,13 @@ from app.models.user import User, UserRole
 
 
 BLOG_KEY_PREFIX = "blog."
+
+_MD_CODE_FENCE_RE = re.compile(r"```.*?```", flags=re.DOTALL)
+_MD_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+_MD_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\([^)]+\)")
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+_MD_STRIP_PREFIX_RE = re.compile(r"(^|\n)(#{1,6}\s*|>\\s*|[-*]\\s+)")
+_MD_MULTI_SPACE_RE = re.compile(r"\s+")
 
 
 def _extract_slug(key: str) -> str:
@@ -31,11 +40,96 @@ def _apply_translation(block: ContentBlock, lang: str | None) -> None:
         block.body_markdown = match.body_markdown
 
 
+def _plain_text_from_markdown(body: str) -> str:
+    text = body or ""
+    text = _MD_CODE_FENCE_RE.sub(" ", text)
+    text = _MD_INLINE_CODE_RE.sub(" ", text)
+    text = _MD_IMAGE_RE.sub(r"\\1", text)
+    text = _MD_LINK_RE.sub(r"\\1", text)
+    text = _MD_STRIP_PREFIX_RE.sub(r"\\1", text)
+    text = _MD_MULTI_SPACE_RE.sub(" ", text).strip()
+    return text
+
+
 def _excerpt(body: str, max_len: int = 180) -> str:
     cleaned = " ".join((body or "").split())
     if len(cleaned) <= max_len:
         return cleaned
     return cleaned[: max_len - 1].rstrip() + "…"
+
+
+def _normalize_tags(raw: object) -> list[str]:
+    if raw is None:
+        return []
+    values: list[str]
+    if isinstance(raw, list):
+        values = [str(v).strip() for v in raw]
+    elif isinstance(raw, str):
+        values = [v.strip() for v in raw.split(",")]
+    else:
+        return []
+
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if not value:
+            continue
+        key = value.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(value)
+    return out
+
+
+def _coerce_positive_int(raw: object) -> int | None:
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw if raw > 0 else None
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        if stripped.isdigit():
+            value = int(stripped)
+            return value if value > 0 else None
+    return None
+
+
+def _compute_reading_time_minutes(body: str) -> int | None:
+    text = _plain_text_from_markdown(body)
+    words = len([w for w in text.split(" ") if w])
+    if words == 0:
+        return None
+    return max(1, math.ceil(words / 200))
+
+
+def _meta_cover_image_url(meta: dict | None) -> str | None:
+    if not meta:
+        return None
+    for key in ("cover_image_url", "cover_image"):
+        value = meta.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _meta_summary(meta: dict | None, *, lang: str | None, base_lang: str | None) -> str | None:
+    if not meta:
+        return None
+    value = meta.get("summary")
+    if isinstance(value, dict):
+        if lang:
+            tr = value.get(lang)
+            if isinstance(tr, str) and tr.strip():
+                return tr.strip()
+        return None
+    if isinstance(value, str) and value.strip():
+        if lang and base_lang and lang != base_lang:
+            return None
+        return value.strip()
+    return None
 
 
 async def list_published_posts(
@@ -44,21 +138,41 @@ async def list_published_posts(
     lang: str | None,
     page: int,
     limit: int,
+    q: str | None = None,
+    tag: str | None = None,
 ) -> tuple[list[ContentBlock], int]:
     page = max(1, page)
     limit = max(1, min(limit, 50))
-    offset = (page - 1) * limit
 
     filters = (ContentBlock.key.like(f"{BLOG_KEY_PREFIX}%"), ContentBlock.status == ContentStatus.published)
+    query_text = (q or "").strip().lower()
+    tag_text = (tag or "").strip().lower()
 
-    total = await session.scalar(select(func.count()).select_from(ContentBlock).where(*filters))
+    if not query_text and not tag_text:
+        offset = (page - 1) * limit
+        total = await session.scalar(select(func.count()).select_from(ContentBlock).where(*filters))
+        query = (
+            select(ContentBlock)
+            .options(selectinload(ContentBlock.images))
+            .where(*filters)
+            .order_by(ContentBlock.published_at.desc().nullslast(), ContentBlock.updated_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        if lang:
+            query = query.options(selectinload(ContentBlock.translations))
+
+        result = await session.execute(query)
+        blocks = list(result.scalars().unique())
+        for block in blocks:
+            _apply_translation(block, lang)
+        return blocks, int(total or 0)
+
     query = (
         select(ContentBlock)
         .options(selectinload(ContentBlock.images))
         .where(*filters)
         .order_by(ContentBlock.published_at.desc().nullslast(), ContentBlock.updated_at.desc())
-        .limit(limit)
-        .offset(offset)
     )
     if lang:
         query = query.options(selectinload(ContentBlock.translations))
@@ -67,7 +181,26 @@ async def list_published_posts(
     blocks = list(result.scalars().unique())
     for block in blocks:
         _apply_translation(block, lang)
-    return blocks, int(total or 0)
+
+    if query_text or tag_text:
+        filtered: list[ContentBlock] = []
+        for block in blocks:
+            meta = getattr(block, "meta", None) or {}
+            if tag_text:
+                tags = _normalize_tags(meta.get("tags"))
+                if tag_text not in {t.lower() for t in tags}:
+                    continue
+            if query_text:
+                haystack = f"{block.title}\n{_plain_text_from_markdown(block.body_markdown)}".lower()
+                if query_text not in haystack:
+                    continue
+            filtered.append(block)
+        blocks = filtered
+
+    total = len(blocks)
+    offset = (page - 1) * limit
+    page_items = blocks[offset : offset + limit]
+    return page_items, total
 
 
 async def get_published_post(
@@ -91,22 +224,35 @@ async def get_published_post(
     return block
 
 
-def to_list_item(block: ContentBlock) -> dict:
-    cover = None
-    if getattr(block, "images", None):
+def to_list_item(block: ContentBlock, *, lang: str | None = None) -> dict:
+    meta = getattr(block, "meta", None) or {}
+    cover = _meta_cover_image_url(meta)
+    if not cover and getattr(block, "images", None):
         first = sorted(block.images, key=lambda img: img.sort_order)[0] if block.images else None
         cover = first.url if first else None
+
+    override_minutes = _coerce_positive_int(meta.get("reading_time_minutes") or meta.get("reading_time"))
+    reading_time_minutes = override_minutes or _compute_reading_time_minutes(block.body_markdown)
+    summary = _meta_summary(meta, lang=lang, base_lang=getattr(block, "lang", None))
+    excerpt = summary or _excerpt(_plain_text_from_markdown(block.body_markdown))
     return {
         "slug": _extract_slug(block.key),
         "title": block.title,
-        "excerpt": _excerpt(block.body_markdown),
+        "excerpt": excerpt,
         "published_at": block.published_at,
         "cover_image_url": cover,
+        "tags": _normalize_tags(meta.get("tags")),
+        "reading_time_minutes": reading_time_minutes,
     }
 
 
-def to_read(block: ContentBlock) -> dict:
+def to_read(block: ContentBlock, *, lang: str | None = None) -> dict:
     images = sorted(getattr(block, "images", []) or [], key=lambda img: img.sort_order)
+    meta = getattr(block, "meta", None) or {}
+    cover = _meta_cover_image_url(meta) or (images[0].url if images else None)
+    override_minutes = _coerce_positive_int(meta.get("reading_time_minutes") or meta.get("reading_time"))
+    reading_time_minutes = override_minutes or _compute_reading_time_minutes(block.body_markdown)
+    summary = _meta_summary(meta, lang=lang, base_lang=getattr(block, "lang", None))
     return {
         "slug": _extract_slug(block.key),
         "title": block.title,
@@ -116,6 +262,10 @@ def to_read(block: ContentBlock) -> dict:
         "updated_at": block.updated_at,
         "images": images,
         "meta": block.meta,
+        "summary": summary,
+        "cover_image_url": cover,
+        "tags": _normalize_tags(meta.get("tags")),
+        "reading_time_minutes": reading_time_minutes,
     }
 
 

--- a/frontend/src/app/core/blog.service.ts
+++ b/frontend/src/app/core/blog.service.ts
@@ -15,6 +15,8 @@ export interface BlogPostListItem {
   excerpt: string;
   published_at?: string | null;
   cover_image_url?: string | null;
+  tags: string[];
+  reading_time_minutes?: number | null;
 }
 
 export interface BlogPostListResponse {
@@ -38,6 +40,10 @@ export interface BlogPost {
   updated_at: string;
   images: BlogPostImage[];
   meta?: Record<string, unknown> | null;
+  summary?: string | null;
+  cover_image_url?: string | null;
+  tags?: string[];
+  reading_time_minutes?: number | null;
 }
 
 export interface BlogCommentAuthor {
@@ -66,11 +72,13 @@ export interface BlogCommentListResponse {
 export class BlogService {
   constructor(private api: ApiService) {}
 
-  listPosts(params: { lang?: string; page?: number; limit?: number }): Observable<BlogPostListResponse> {
+  listPosts(params: { lang?: string; page?: number; limit?: number; q?: string; tag?: string }): Observable<BlogPostListResponse> {
     return this.api.get<BlogPostListResponse>('/blog/posts', {
       lang: params.lang,
       page: params.page ?? 1,
-      limit: params.limit ?? 10
+      limit: params.limit ?? 10,
+      q: params.q,
+      tag: params.tag
     });
   }
 

--- a/frontend/src/app/pages/blog/blog-post.component.ts
+++ b/frontend/src/app/pages/blog/blog-post.component.ts
@@ -41,7 +41,19 @@ import { SkeletonComponent } from '../../shared/skeleton.component';
         </h1>
         <p class="text-sm text-slate-500 dark:text-slate-400" *ngIf="post()?.published_at">
           {{ post()!.published_at | date: 'mediumDate' }}
+          <ng-container *ngIf="post()?.reading_time_minutes"> · {{ 'blog.minutesRead' | translate : { minutes: post()!.reading_time_minutes } }}</ng-container>
         </p>
+        <p class="text-sm text-slate-600 dark:text-slate-300" *ngIf="post()?.summary">{{ post()!.summary }}</p>
+        <div class="flex flex-wrap gap-1" *ngIf="post()?.tags?.length">
+          <a
+            *ngFor="let tag of post()!.tags"
+            [routerLink]="['/blog']"
+            [queryParams]="{ tag: tag }"
+            class="text-xs rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-slate-700 hover:border-slate-300 hover:bg-white dark:border-slate-700 dark:bg-slate-950/30 dark:text-slate-200 dark:hover:border-slate-600"
+          >
+            #{{ tag }}
+          </a>
+        </div>
       </div>
 
       <div *ngIf="loadingPost()" class="grid gap-4">
@@ -64,9 +76,9 @@ import { SkeletonComponent } from '../../shared/skeleton.component';
         <app-card>
           <div class="grid gap-6">
             <img
-              *ngIf="post()!.images?.length"
-              [src]="post()!.images[0].url"
-              [alt]="post()!.images[0].alt_text || post()!.title"
+              *ngIf="post()!.cover_image_url"
+              [src]="post()!.cover_image_url"
+              [alt]="post()!.title"
               class="w-full rounded-2xl border border-slate-200 bg-slate-50 object-cover dark:border-slate-800 dark:bg-slate-800"
               loading="lazy"
             />
@@ -399,15 +411,15 @@ export class BlogPostComponent implements OnInit, OnDestroy {
 
   private setMetaTags(post: BlogPost): void {
     const pageTitle = `${post.title} | AdrianaArt`;
-    const description = (post.body_markdown || '').replace(/\s+/g, ' ').trim().slice(0, 160);
+    const description = (post.summary || post.body_markdown || '').replace(/\s+/g, ' ').trim().slice(0, 160);
     this.title.setTitle(pageTitle);
     if (description) {
       this.meta.updateTag({ name: 'description', content: description });
       this.meta.updateTag({ property: 'og:description', content: description });
     }
     this.meta.updateTag({ property: 'og:title', content: pageTitle });
-    if (post.images?.length) {
-      this.meta.updateTag({ property: 'og:image', content: post.images[0].url });
+    if (post.cover_image_url) {
+      this.meta.updateTag({ property: 'og:image', content: post.cover_image_url });
     }
     this.setCanonical();
   }

--- a/frontend/src/app/shared/input.component.ts
+++ b/frontend/src/app/shared/input.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { NgClass, NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -13,6 +13,7 @@ import { FormsModule } from '@angular/forms';
         class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-900 shadow-sm focus:border-slate-400 focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
         [placeholder]="placeholder"
         [(ngModel)]="value"
+        (ngModelChange)="valueChange.emit($event)"
         [type]="type"
       />
       <span *ngIf="hint" class="text-xs text-slate-500 dark:text-slate-400">{{ hint }}</span>
@@ -25,4 +26,5 @@ export class InputComponent {
   @Input() type: 'text' | 'email' | 'password' = 'text';
   @Input() hint = '';
   @Input() value: string | number = '';
+  @Output() valueChange = new EventEmitter<string | number>();
 }

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -28,6 +28,13 @@
   },
   "blog": {
     "title": "Blog",
+    "searchLabel": "Search",
+    "searchPlaceholder": "Search posts",
+    "tagLabel": "Tag",
+    "tagPlaceholder": "Filter by tag",
+    "searchCta": "Search",
+    "clearFilters": "Clear",
+    "minutesRead": "{{minutes}} min read",
     "errorTitle": "Could not load posts.",
     "errorCopy": "Check your connection and retry.",
     "retry": "Retry",

--- a/frontend/src/assets/i18n/ro.json
+++ b/frontend/src/assets/i18n/ro.json
@@ -28,6 +28,13 @@
   },
   "blog": {
     "title": "Blog",
+    "searchLabel": "Caută",
+    "searchPlaceholder": "Caută articole",
+    "tagLabel": "Etichetă",
+    "tagPlaceholder": "Filtrează după etichetă",
+    "searchCta": "Căutare",
+    "clearFilters": "Șterge",
+    "minutesRead": "{{minutes}} min citire",
     "errorTitle": "Nu am putut încărca postările.",
     "errorCopy": "Verifică conexiunea și încearcă din nou.",
     "retry": "Reîncearcă",


### PR DESCRIPTION
**Summary**
- Adds blog post metadata (summary/cover/tags/reading time) stored in `ContentBlock.meta` and surfaces it in the public blog API + UI.

**Changes**
- Backend: extend blog list/detail responses with `tags` + `reading_time_minutes` and derive excerpt/cover/summary from `ContentBlock.meta`.
- Backend: add `q` (search) and `tag` filters to `GET /api/v1/blog/posts`.
- Frontend: add blog list search + tag filter UI (query params) and show tags/reading time in cards.
- Frontend: improve blog post header (summary/tags) and use `cover_image_url`/summary for SEO meta.
- Admin: add blog metadata fields to the editor and fix `app-input` two-way binding.
- Tests: expand `backend/tests/test_blog_api.py` to cover metadata + filtering.

**Testing**
- `PYTHONPATH=backend pytest backend/tests/test_blog_api.py`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

**Risk & Impact**
- Low: changes are additive to API responses and UI; list endpoint retains efficient DB pagination when no filters are used.

**Related TODO items**
- [x] Metadata: add summary, cover_image, tags, reading_time to ContentBlock.meta and show them in list/cards.
- [x] Filters: tag filter + search within blog posts (server-side).