### PR TITLE
feat: add blog previews, scheduling, revisions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -233,10 +233,12 @@ Below is a structured checklist you can turn into issues.
 - [x] SEO: include blog URLs in sitemap.xml and add OpenGraph meta per post.
 - [x] Metadata: add summary, cover_image, tags, reading_time to ContentBlock.meta and show them in list/cards.
 - [x] Filters: tag filter + search within blog posts (server-side).
-- [ ] Draft previews: shareable preview URL (token-based) for unpublished posts.
-- [ ] Scheduling: support publish_at / scheduled publishing and “unpublish”.
-- [ ] WYSIWYG upgrade (ProseMirror/Quill/etc.) with Markdown export/import.
-- [ ] Revisions: show version history and diff/rollback per post.
+- [x] Draft previews: shareable preview URL (token-based) for unpublished posts.
+- [x] Scheduling: support publish_at / scheduled publishing and “unpublish”.
+- [x] WYSIWYG editor (Toast UI) with Markdown import/export.
+- [x] Revisions: show version history and diff/rollback per post.
+- [ ] Revisions v2: include meta/translations/published_at in version snapshots + rollback.
+- [ ] Editor: improve dark-mode styling for the rich editor UI.
 - [ ] Social preview images (OG image generation per post).
 - [ ] Moderation: admin tools to hide/delete comments and review flagged content.
 - [ ] Notifications: optional email notifications for new comments (admin/user opt-in).

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -40,3 +40,16 @@ def decode_token(token: str) -> Optional[dict[str, Any]]:
         return jwt.decode(token, settings.secret_key, algorithms=[settings.jwt_algorithm])
     except JWTError:
         return None
+
+
+def create_content_preview_token(*, content_key: str, expires_at: datetime) -> str:
+    to_encode = {"type": "content_preview", "key": content_key, "exp": expires_at}
+    return jwt.encode(to_encode, settings.secret_key, algorithm=settings.jwt_algorithm)
+
+
+def decode_content_preview_token(token: str) -> str | None:
+    payload = decode_token(token)
+    if not payload or payload.get("type") != "content_preview":
+        return None
+    key = payload.get("key")
+    return str(key) if isinstance(key, str) and key else None

--- a/backend/app/schemas/blog.py
+++ b/backend/app/schemas/blog.py
@@ -21,6 +21,12 @@ class BlogPostListResponse(BaseModel):
     meta: PaginationMeta
 
 
+class BlogPreviewTokenResponse(BaseModel):
+    token: str
+    expires_at: datetime
+    url: str
+
+
 class BlogPostImage(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/schemas/content.py
+++ b/backend/app/schemas/content.py
@@ -11,6 +11,7 @@ class ContentBlockBase(BaseModel):
     title: str = Field(min_length=1, max_length=200)
     body_markdown: str = Field(min_length=1)
     status: ContentStatus = ContentStatus.draft
+    published_at: datetime | None = None
     meta: dict[str, Any] | None = None
     sort_order: int = 0
     lang: str | None = Field(default=None, pattern="^(en|ro)$")
@@ -31,6 +32,7 @@ class ContentBlockUpdate(BaseModel):
     title: str | None = Field(default=None, max_length=200)
     body_markdown: str | None = Field(default=None)
     status: ContentStatus | None = None
+    published_at: datetime | None = None
     meta: dict[str, Any] | None = None
     sort_order: int | None = None
     lang: str | None = Field(default=None, pattern="^(en|ro)$")
@@ -68,6 +70,20 @@ class ContentImageRead(BaseModel):
     url: str
     alt_text: str | None = None
     sort_order: int
+
+
+class ContentBlockVersionListItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    version: int
+    title: str
+    status: ContentStatus
+    created_at: datetime
+
+
+class ContentBlockVersionRead(ContentBlockVersionListItem):
+    body_markdown: str
 
 
 class ContentAuditRead(BaseModel):

--- a/backend/tests/test_blog_api.py
+++ b/backend/tests/test_blog_api.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timedelta, timezone
 from typing import Dict
 
 import pytest
@@ -133,6 +134,68 @@ def test_blog_posts_list_detail_and_comments(test_app: Dict[str, object]) -> Non
     assert filtered_q.status_code == 200, filtered_q.text
     assert filtered_q.json()["meta"]["total_items"] == 1
     assert filtered_q.json()["items"][0]["slug"] == "second-post"
+
+    # Scheduling: published posts with a future published_at should not be visible yet.
+    future = (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()
+    scheduled = client.post(
+        "/api/v1/content/admin/blog.scheduled-post",
+        json={
+            "title": "Scheduled",
+            "body_markdown": "This is scheduled.",
+            "status": "published",
+            "lang": "en",
+            "published_at": future,
+        },
+        headers=auth_headers(admin_token),
+    )
+    assert scheduled.status_code == 201, scheduled.text
+
+    listing_after_schedule = client.get("/api/v1/blog/posts", params={"lang": "en"})
+    assert listing_after_schedule.status_code == 200, listing_after_schedule.text
+    assert listing_after_schedule.json()["meta"]["total_items"] == 2
+    assert {i["slug"] for i in listing_after_schedule.json()["items"]} == {"first-post", "second-post"}
+
+    scheduled_detail = client.get("/api/v1/blog/posts/scheduled-post", params={"lang": "en"})
+    assert scheduled_detail.status_code == 404, scheduled_detail.text
+
+    # Draft previews: admin can mint a token and fetch the unpublished/scheduled post.
+    minted = client.post(
+        "/api/v1/blog/posts/scheduled-post/preview-token",
+        params={"lang": "en"},
+        headers=auth_headers(admin_token),
+    )
+    assert minted.status_code == 200, minted.text
+    token = minted.json()["token"]
+    assert token
+
+    preview = client.get("/api/v1/blog/posts/scheduled-post/preview", params={"lang": "en", "token": token})
+    assert preview.status_code == 200, preview.text
+    assert preview.json()["title"] == "Scheduled"
+
+    wrong = client.get("/api/v1/blog/posts/first-post/preview", params={"token": token})
+    assert wrong.status_code == 403, wrong.text
+
+    # Revisions: base updates create versions and rollback restores previous snapshot.
+    update_base = client.patch(
+        "/api/v1/content/admin/blog.first-post",
+        json={"title": "Salut (v2)", "body_markdown": "Postare RO v2"},
+        headers=auth_headers(admin_token),
+    )
+    assert update_base.status_code == 200, update_base.text
+
+    versions = client.get("/api/v1/content/admin/blog.first-post/versions", headers=auth_headers(admin_token))
+    assert versions.status_code == 200, versions.text
+    versions_json = versions.json()
+    assert versions_json[0]["version"] == 2
+    assert versions_json[-1]["version"] == 1
+
+    v1 = client.get("/api/v1/content/admin/blog.first-post/versions/1", headers=auth_headers(admin_token))
+    assert v1.status_code == 200, v1.text
+
+    rolled = client.post("/api/v1/content/admin/blog.first-post/versions/1/rollback", headers=auth_headers(admin_token))
+    assert rolled.status_code == 200, rolled.text
+    assert rolled.json()["title"] == v1.json()["title"]
+    assert rolled.json()["body_markdown"] == v1.json()["body_markdown"]
 
     # Comments: create and list
     created = client.post(

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -18,12 +18,12 @@
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/styles.css"],
+            "styles": ["src/styles.css", "node_modules/@toast-ui/editor/dist/toastui-editor.css"],
             "scripts": [],
             "budgets": [
               {
                 "type": "initial",
-                "maximumWarning": "820kb",
+                "maximumWarning": "950kb",
                 "maximumError": "950kb"
               },
               {
@@ -54,7 +54,7 @@
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.cjs",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/styles.css"],
+            "styles": ["src/styles.css", "node_modules/@toast-ui/editor/dist/toastui-editor.css"],
             "scripts": []
           }
         }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,8 @@
         "@ngx-translate/http-loader": "^16.0.0",
         "@sentry/browser": "^10.32.1",
         "@stripe/stripe-js": "^4.10.0",
+        "@toast-ui/editor": "^3.2.2",
+        "diff": "^8.0.2",
         "dompurify": "^3.3.1",
         "marked": "^17.0.1",
         "rxjs": "^7.8.1",
@@ -4561,6 +4563,28 @@
         "node": ">=12.16"
       }
     },
+    "node_modules/@toast-ui/editor": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@toast-ui/editor/-/editor-3.2.2.tgz",
+      "integrity": "sha512-ASX7LFjN2ZYQJrwmkUajPs7DRr9FsM1+RQ82CfTO0Y5ZXorBk1VZS4C2Dpxinx9kl55V4F8/A2h2QF4QMDtRbA==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^2.3.3",
+        "prosemirror-commands": "^1.1.9",
+        "prosemirror-history": "^1.1.3",
+        "prosemirror-inputrules": "^1.1.3",
+        "prosemirror-keymap": "^1.1.4",
+        "prosemirror-model": "^1.14.1",
+        "prosemirror-state": "^1.3.4",
+        "prosemirror-view": "^1.18.7"
+      }
+    },
+    "node_modules/@toast-ui/editor/node_modules/dompurify": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
+    },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -6939,6 +6963,15 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -11486,6 +11519,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -12215,6 +12254,89 @@
         "node": ">=10"
       }
     },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.5.tgz",
+      "integrity": "sha512-RPDQCxIDhIBb1o36xxwsaeAvivO8VLJcgBtzmOwQ64bMtsVFh5SSuJ6dWSxO1UsHTiTXPCgQm3PDJt7p6IOLbw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.4.tgz",
+      "integrity": "sha512-WkKgnyjNncri03Gjaz3IFWvCAE94XoiEgvtr0/r2Xw7R8/IjK3sKLSiDoCHWcsXSAinVaKlGRZDvMCsF1kbzjA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -12720,6 +12842,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.22.4",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -15050,6 +15178,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/watchpack": {
       "version": "2.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,8 @@
     "@ngx-translate/http-loader": "^16.0.0",
     "@sentry/browser": "^10.32.1",
     "@stripe/stripe-js": "^4.10.0",
+    "@toast-ui/editor": "^3.2.2",
+    "diff": "^8.0.2",
     "dompurify": "^3.3.1",
     "marked": "^17.0.1",
     "rxjs": "^7.8.1",

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -7,7 +7,6 @@ import { AboutComponent } from './pages/about/about.component';
 import { BlogListComponent } from './pages/blog/blog-list.component';
 import { BlogPostComponent } from './pages/blog/blog-post.component';
 import { ProductComponent } from './pages/product/product.component';
-import { AdminComponent } from './pages/admin/admin.component';
 import { authGuard, adminGuard } from './core/auth.guard';
 import { CartComponent } from './pages/cart/cart.component';
 import { CheckoutComponent } from './pages/checkout/checkout.component';
@@ -38,7 +37,12 @@ export const routes: Routes = [
   { path: 'password-reset/confirm', component: PasswordResetComponent, title: 'Set new password | AdrianaArt' },
   { path: 'account', canActivate: [authGuard], component: AccountComponent, title: 'Account | AdrianaArt' },
   { path: 'account/password', canActivate: [authGuard], component: ChangePasswordComponent, title: 'Change password | AdrianaArt' },
-  { path: 'admin', component: AdminComponent, canActivate: [adminGuard], title: 'Admin' },
+  {
+    path: 'admin',
+    canActivate: [adminGuard],
+    loadComponent: () => import('./pages/admin/admin.component').then((m) => m.AdminComponent),
+    title: 'Admin'
+  },
   { path: 'error', component: ErrorComponent, title: 'Something went wrong' },
   { path: '**', component: NotFoundComponent, title: 'Not Found' }
 ];

--- a/frontend/src/app/core/admin.service.ts
+++ b/frontend/src/app/core/admin.service.ts
@@ -52,6 +52,7 @@ export interface AdminContent {
   meta?: Record<string, any> | null;
   lang?: string | null;
   sort_order?: number | null;
+  published_at?: string | null;
 }
 
 export interface AdminCoupon {
@@ -123,7 +124,20 @@ export interface ContentBlock {
   meta?: Record<string, any> | null;
   lang?: string | null;
   sort_order?: number;
+  published_at?: string | null;
   images?: { id: string; url: string; alt_text?: string | null; sort_order?: number }[];
+}
+
+export interface ContentBlockVersionListItem {
+  id: string;
+  version: number;
+  title: string;
+  status: string;
+  created_at: string;
+}
+
+export interface ContentBlockVersionRead extends ContentBlockVersionListItem {
+  body_markdown: string;
 }
 
 export interface ContentSavePayload {
@@ -290,5 +304,17 @@ export class AdminService {
     form.append('file', file);
     const suffix = lang ? `?lang=${lang}` : '';
     return this.api.post<ContentBlock>(`/content/admin/${key}/images${suffix}`, form);
+  }
+
+  listContentVersions(key: string): Observable<ContentBlockVersionListItem[]> {
+    return this.api.get<ContentBlockVersionListItem[]>(`/content/admin/${key}/versions`);
+  }
+
+  getContentVersion(key: string, version: number): Observable<ContentBlockVersionRead> {
+    return this.api.get<ContentBlockVersionRead>(`/content/admin/${key}/versions/${version}`);
+  }
+
+  rollbackContentVersion(key: string, version: number): Observable<ContentBlock> {
+    return this.api.post<ContentBlock>(`/content/admin/${key}/versions/${version}/rollback`, {});
   }
 }

--- a/frontend/src/app/core/blog.service.ts
+++ b/frontend/src/app/core/blog.service.ts
@@ -24,6 +24,12 @@ export interface BlogPostListResponse {
   meta: PaginationMeta;
 }
 
+export interface BlogPreviewTokenResponse {
+  token: string;
+  expires_at: string;
+  url: string;
+}
+
 export interface BlogPostImage {
   id: string;
   url: string;
@@ -84,6 +90,21 @@ export class BlogService {
 
   getPost(slug: string, lang?: string): Observable<BlogPost> {
     return this.api.get<BlogPost>(`/blog/posts/${slug}`, { lang });
+  }
+
+  getPreviewPost(slug: string, token: string, lang?: string): Observable<BlogPost> {
+    return this.api.get<BlogPost>(`/blog/posts/${slug}/preview`, { token, lang });
+  }
+
+  createPreviewToken(
+    slug: string,
+    params: { lang?: string; expires_minutes?: number } = {}
+  ): Observable<BlogPreviewTokenResponse> {
+    const qs = new URLSearchParams();
+    if (params.lang) qs.set('lang', params.lang);
+    if (params.expires_minutes) qs.set('expires_minutes', String(params.expires_minutes));
+    const suffix = qs.toString() ? `?${qs.toString()}` : '';
+    return this.api.post<BlogPreviewTokenResponse>(`/blog/posts/${slug}/preview-token${suffix}`, {});
   }
 
   listComments(slug: string, params: { page?: number; limit?: number } = {}): Observable<BlogCommentListResponse> {

--- a/frontend/src/app/shared/rich-editor.component.ts
+++ b/frontend/src/app/shared/rich-editor.component.ts
@@ -1,0 +1,62 @@
+import { AfterViewInit, Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
+import Editor from '@toast-ui/editor';
+
+@Component({
+  selector: 'app-rich-editor',
+  standalone: true,
+  template: `<div #host class="rounded-lg border border-slate-200 bg-white text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"></div>`
+})
+export class RichEditorComponent implements AfterViewInit, OnChanges, OnDestroy {
+  @ViewChild('host', { static: true }) host!: ElementRef<HTMLDivElement>;
+
+  @Input() value = '';
+  @Output() valueChange = new EventEmitter<string>();
+
+  @Input() height = '420px';
+  @Input() initialEditType: 'markdown' | 'wysiwyg' = 'markdown';
+
+  private editor: Editor | null = null;
+  private isApplyingExternalUpdate = false;
+
+  ngAfterViewInit(): void {
+    this.editor = new Editor({
+      el: this.host.nativeElement,
+      height: this.height,
+      initialEditType: this.initialEditType,
+      previewStyle: 'vertical',
+      hideModeSwitch: false,
+      usageStatistics: false,
+      initialValue: this.value || ''
+    });
+
+    this.editor.on('change', () => {
+      if (!this.editor || this.isApplyingExternalUpdate) return;
+      const next = this.editor.getMarkdown();
+      this.value = next;
+      this.valueChange.emit(next);
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!this.editor) return;
+    if (!changes['value']) return;
+    const next = this.value || '';
+    const current = this.editor.getMarkdown();
+    if (next === current) return;
+
+    this.isApplyingExternalUpdate = true;
+    this.editor.setMarkdown(next, false);
+    this.isApplyingExternalUpdate = false;
+  }
+
+  insertMarkdown(text: string): void {
+    if (!this.editor) return;
+    this.editor.insertText(text);
+  }
+
+  ngOnDestroy(): void {
+    this.editor?.destroy();
+    this.editor = null;
+  }
+}
+

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -35,6 +35,9 @@
     "searchCta": "Search",
     "clearFilters": "Clear",
     "minutesRead": "{{minutes}} min read",
+    "preview": {
+      "banner": "Preview mode — this post is not published yet."
+    },
     "errorTitle": "Could not load posts.",
     "errorCopy": "Check your connection and retry.",
     "retry": "Retry",

--- a/frontend/src/assets/i18n/ro.json
+++ b/frontend/src/assets/i18n/ro.json
@@ -35,6 +35,9 @@
     "searchCta": "Căutare",
     "clearFilters": "Șterge",
     "minutesRead": "{{minutes}} min citire",
+    "preview": {
+      "banner": "Mod previzualizare — acest articol nu este încă publicat."
+    },
     "errorTitle": "Nu am putut încărca postările.",
     "errorCopy": "Verifică conexiunea și încearcă din nou.",
     "retry": "Reîncearcă",

--- a/frontend/src/types/toast-ui-editor.d.ts
+++ b/frontend/src/types/toast-ui-editor.d.ts
@@ -1,0 +1,21 @@
+declare module '@toast-ui/editor' {
+  export interface EditorOptions {
+    el: HTMLElement;
+    height?: string;
+    initialEditType?: 'markdown' | 'wysiwyg';
+    previewStyle?: 'tab' | 'vertical';
+    hideModeSwitch?: boolean;
+    usageStatistics?: boolean;
+    initialValue?: string;
+  }
+
+  export default class Editor {
+    constructor(options: EditorOptions);
+    on(eventName: string, handler: () => void): void;
+    getMarkdown(): string;
+    setMarkdown(markdown: string, cursorToEnd?: boolean): void;
+    insertText(text: string): void;
+    destroy(): void;
+  }
+}
+


### PR DESCRIPTION
**Summary**
- Adds scheduled publishing and shareable preview links for blog posts, plus admin revisions (diff/rollback) and a rich WYSIWYG editor for authoring.

**Changes**
- Backend: add preview-token endpoints, scheduled publish filtering, content version list/detail + rollback endpoints, and exclude scheduled posts from sitemap.
- Frontend: support preview mode on `/blog/:slug`, add publish-at + preview link + revisions UI in `/admin`, and integrate Toast UI editor (lazy-loaded with admin route).
- Backlog: mark the completed blog publishing tasks and add follow-up TODOs for richer revisions + dark-mode editor styling.

**Testing**
- `PYTHONPATH=backend pytest backend/tests/test_blog_api.py`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

**Risk & Impact**
- `/admin` is now lazy-loaded; should be transparent but changes bundling/loading behavior.
- Preview links are JWT-based and expire; ensure `SECRET_KEY` remains stable across environments.

**Related TODO items**
- [x] Draft previews: shareable preview URL (token-based) for unpublished posts.
- [x] Scheduling: support publish_at / scheduled publishing and “unpublish”.
- [x] WYSIWYG editor (Toast UI) with Markdown import/export.
- [x] Revisions: show version history and diff/rollback per post.