### PR TITLE
fix: auto-generate slugs and revalidate sessions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,6 +57,7 @@ Below is a structured checklist you can turn into issues.
 - [x] Seed example products/categories for dev.
 - [x] SKU generation and uniqueness enforcement.
 - [x] Slug collision handling and validator.
+- [x] Auto-generate product/category slugs (admin UX) and make slugs immutable; free product slugs on delete.
 - [x] Product status enums (draft/published/archived).
 - [x] Track publish date and last_modified.
 - [x] Bulk price/stock update endpoint for admins.
@@ -69,7 +70,7 @@ Below is a structured checklist you can turn into issues.
 - [x] Recently viewed products service (per session).
 - [x] Admin export products CSV.
 - [x] Admin import products CSV with dry-run validation.
-- [x] Product slug history/redirects on slug change.
+- [x] Product slug history/redirects for legacy slugs (slugs are immutable going forward).
 - [x] Server-side pagination metadata (total pages/items).
 - [x] Sort options: newest, price asc/desc, name asc/desc.
 - [x] Backorder/preorder flag + estimated restock date.
@@ -312,6 +313,8 @@ Below is a structured checklist you can turn into issues.
 - [x] Shipping method selection UI.
 - [x] Address form with validation and country selector.
 - [x] Payment form with Stripe elements.
+- [ ] Checkout: add a billing address section with a “same as shipping” toggle and persist/attach it to orders.
+- [ ] Payments UX: add payment method icons and implement Cash on delivery (RON) as an additional option (PayPal optional follow-up).
 - [x] Checkout error states and retry.
 - [x] Save address checkbox for checkout.
 - [x] Order confirmation page with next steps.
@@ -376,7 +379,7 @@ Below is a structured checklist you can turn into issues.
 - [x] Admin UX: add `/admin/products` page (catalog workflows) and wire it into the admin sidebar.
 - [x] Admin UX: add `/admin/users` page (users + security workflows) and wire it into the admin sidebar.
 - [x] Product list table (sort/search).
-- [x] Product create/edit form (slug, category, price, stock, description, images, variants).
+- [x] Product create/edit form (slug auto-generated, category, price, stock, description, images, variants).
 - [x] Admin orders list with filters + order detail/status update.
 - [x] Admin orders: add actions (retry/capture/void/refund note, delivery email, packing slip download).
 - [x] Content editor for hero and static pages.

--- a/backend/app/schemas/catalog.py
+++ b/backend/app/schemas/catalog.py
@@ -7,18 +7,22 @@ from pydantic import field_validator
 from app.models.catalog import ProductStatus
 
 
-class CategoryBase(BaseModel):
-    slug: str = Field(min_length=1, max_length=120)
+class CategoryFields(BaseModel):
     name: str = Field(min_length=1, max_length=120)
     description: str | None = None
     sort_order: int = 0
 
 
-class CategoryCreate(CategoryBase):
-    pass
+class CategoryBase(CategoryFields):
+    slug: str = Field(min_length=1, max_length=120)
+
+
+class CategoryCreate(CategoryFields):
+    slug: str | None = Field(default=None, min_length=1, max_length=120)
 
 
 class CategoryUpdate(BaseModel):
+    slug: str | None = Field(default=None, min_length=1, max_length=120)
     name: str | None = Field(default=None, max_length=120)
     description: str | None = None
     sort_order: int | None = None
@@ -49,9 +53,8 @@ class CategoryTranslationRead(CategoryTranslationUpsert):
     lang: str
 
 
-class ProductBase(BaseModel):
+class ProductFields(BaseModel):
     category_id: UUID
-    slug: str = Field(min_length=1, max_length=160)
     sku: str | None = Field(default=None, min_length=3, max_length=64)
     name: str = Field(min_length=1, max_length=160)
     short_description: str | None = Field(default=None, max_length=280)
@@ -84,6 +87,10 @@ class ProductBase(BaseModel):
         if cleaned != "RON":
             raise ValueError("Only RON currency is supported")
         return cleaned
+
+
+class ProductBase(ProductFields):
+    slug: str = Field(min_length=1, max_length=160)
 
 
 class ProductImageBase(BaseModel):
@@ -187,7 +194,8 @@ class PaginationMeta(BaseModel):
     limit: int
 
 
-class ProductCreate(ProductBase):
+class ProductCreate(ProductFields):
+    slug: str | None = Field(default=None, min_length=1, max_length=160)
     images: list[ProductImageCreate] = []
     variants: list[ProductVariantCreate] = []
     tags: list[str] = []

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -16,6 +16,7 @@ describe('AppComponent', () => {
           useValue: {
             user: () => null,
             isAuthenticated: () => false,
+            loadCurrentUser: () => of(null),
             updatePreferredLanguage: () => of(null)
           }
         }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -8,6 +8,7 @@ import { ToastService } from './core/toast.service';
 import { ThemeService, ThemePreference } from './core/theme.service';
 import { TranslateService } from '@ngx-translate/core';
 import { LanguageService } from './core/language.service';
+import { AuthService } from './core/auth.service';
 
 @Component({
   selector: 'app-root',
@@ -39,9 +40,14 @@ export class AppComponent {
     private toast: ToastService,
     private theme: ThemeService,
     private translate: TranslateService,
-    private lang: LanguageService
+    private lang: LanguageService,
+    private auth: AuthService
   ) {
     // Language is handled by LanguageService (localStorage + preferred_language + browser fallback).
+    // Revalidate any persisted session on startup to avoid "logged in but unauthorized" UI states.
+    if (this.auth.isAuthenticated()) {
+      this.auth.loadCurrentUser().subscribe({ error: () => void 0 });
+    }
   }
 
   onThemeChange(pref: ThemePreference): void {

--- a/frontend/src/app/core/http.interceptor.ts
+++ b/frontend/src/app/core/http.interceptor.ts
@@ -1,13 +1,41 @@
 import { inject } from '@angular/core';
-import { HttpInterceptorFn } from '@angular/common/http';
-import { catchError } from 'rxjs/operators';
-import { throwError } from 'rxjs';
+import { HttpBackend, HttpClient, HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { catchError, finalize, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { Observable, throwError } from 'rxjs';
 import { ErrorHandlerService } from '../shared/error-handler.service';
-import { AuthService } from './auth.service';
+import { AuthService, AuthTokens } from './auth.service';
+import { appConfig } from './app-config';
+
+let refreshInFlight: Observable<AuthTokens> | null = null;
+
+function getApiBaseUrl(): string {
+  return appConfig.apiBaseUrl.replace(/\/$/, '');
+}
+
+function refreshTokens(rawHttp: HttpClient, auth: AuthService): Observable<AuthTokens> {
+  if (refreshInFlight) return refreshInFlight;
+  const refreshToken = auth.getRefreshToken();
+  if (!refreshToken) {
+    return throwError(() => new Error('No refresh token available'));
+  }
+  const apiBase = getApiBaseUrl();
+  refreshInFlight = rawHttp
+    .post<AuthTokens>(`${apiBase}/auth/refresh`, { refresh_token: refreshToken }, { withCredentials: true })
+    .pipe(
+      tap((tokens) => auth.setTokens(tokens)),
+      finalize(() => {
+        refreshInFlight = null;
+      }),
+      shareReplay(1)
+    );
+  return refreshInFlight;
+}
 
 export const authAndErrorInterceptor: HttpInterceptorFn = (req, next) => {
   const handler = inject(ErrorHandlerService);
   const auth = inject(AuthService);
+  const backend = inject(HttpBackend);
+  const rawHttp = new HttpClient(backend);
   const token = auth.getAccessToken();
 
   const hasAuthHeader = req.headers.has('Authorization');
@@ -20,6 +48,43 @@ export const authAndErrorInterceptor: HttpInterceptorFn = (req, next) => {
 
   return next(authReq).pipe(
     catchError((err) => {
+      const apiBase = getApiBaseUrl();
+      const isApiRequest = req.url.startsWith(apiBase);
+      const isRefresh = req.url === `${apiBase}/auth/refresh`;
+      const isLogin = req.url === `${apiBase}/auth/login`;
+      const isRegister = req.url === `${apiBase}/auth/register`;
+      const isLogout = req.url === `${apiBase}/auth/logout`;
+      const isGoogleFlow = req.url.startsWith(`${apiBase}/auth/google/`);
+
+      if (
+        err instanceof HttpErrorResponse &&
+        err.status === 401 &&
+        isApiRequest &&
+        !hasAuthHeader &&
+        !isRefresh &&
+        !isLogin &&
+        !isRegister &&
+        !isLogout &&
+        !isGoogleFlow &&
+        auth.getRefreshToken()
+      ) {
+        return refreshTokens(rawHttp, auth).pipe(
+          switchMap(() => {
+            const nextToken = auth.getAccessToken();
+            const retryReq = req.clone({
+              withCredentials: true,
+              setHeaders: nextToken ? { Authorization: `Bearer ${nextToken}` } : {}
+            });
+            return next(retryReq);
+          }),
+          catchError((refreshErr) => {
+            auth.clearSession();
+            handler.handle(refreshErr);
+            return throwError(() => err);
+          })
+        );
+      }
+
       handler.handle(err);
       return throwError(() => err);
     })

--- a/frontend/src/app/pages/admin/admin.component.ts
+++ b/frontend/src/app/pages/admin/admin.component.ts
@@ -1086,11 +1086,11 @@ type PageBlockDraft = Omit<HomeBlockDraft, 'type'> & { type: PageBlockType };
             <div class="flex items-center justify-between">
               <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-50">{{ 'adminUi.categories.title' | translate }}</h2>
             </div>
-            <div class="grid md:grid-cols-3 gap-2 items-end text-sm">
+            <div class="grid md:grid-cols-[1fr_auto] gap-2 items-end text-sm">
               <app-input [label]="'adminUi.products.table.name' | translate" [(value)]="categoryName"></app-input>
-              <app-input [label]="'adminUi.categories.slug' | translate" [(value)]="categorySlug"></app-input>
               <app-button size="sm" [label]="'adminUi.categories.add' | translate" (action)="addCategory()"></app-button>
             </div>
+            <p class="text-xs text-slate-500 dark:text-slate-400">{{ 'adminUi.categories.slugAutoHint' | translate }}</p>
 	            <div class="grid gap-2 text-sm text-slate-700 dark:text-slate-200">
 	              <div
 	                *ngFor="let cat of categories"
@@ -2142,7 +2142,6 @@ export class AdminComponent implements OnInit, OnDestroy {
   products: AdminProduct[] = [];
   categories: AdminCategory[] = [];
   categoryName = '';
-  categorySlug = '';
   categoryTranslationsSlug: string | null = null;
   categoryTranslationsError = signal<string | null>(null);
   categoryTranslationExists: Record<'en' | 'ro', boolean> = { en: false, ro: false };
@@ -2744,15 +2743,14 @@ export class AdminComponent implements OnInit, OnDestroy {
   }
 
   addCategory(): void {
-    if (!this.categoryName || !this.categorySlug) {
+    if (!this.categoryName) {
       this.toast.error(this.t('adminUi.products.errors.required'));
       return;
     }
-    this.admin.createCategory({ name: this.categoryName, slug: this.categorySlug }).subscribe({
+    this.admin.createCategory({ name: this.categoryName }).subscribe({
       next: (cat) => {
         this.categories = [cat, ...this.categories];
         this.categoryName = '';
-        this.categorySlug = '';
         this.toast.success(this.t('adminUi.categories.success.add'));
       },
       error: () => this.toast.error(this.t('adminUi.categories.errors.add'))

--- a/frontend/src/app/pages/admin/products/admin-products.component.ts
+++ b/frontend/src/app/pages/admin/products/admin-products.component.ts
@@ -16,7 +16,6 @@ type ProductStatusFilter = 'all' | 'draft' | 'published' | 'archived';
 
 type ProductForm = {
   name: string;
-  slug: string;
   category_id: string;
   base_price: number;
   stock_quantity: number;
@@ -194,7 +193,15 @@ type ProductTranslationForm = {
 
         <div class="grid gap-3 md:grid-cols-2">
           <app-input [label]="'adminUi.products.table.name' | translate" [(value)]="form.name"></app-input>
-          <app-input [label]="'adminUi.products.form.slug' | translate" [(value)]="form.slug"></app-input>
+          <div class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+            <span>{{ 'adminUi.products.form.slug' | translate }}</span>
+            <div class="h-10 rounded-lg border border-slate-200 bg-slate-50 px-3 text-sm text-slate-900 shadow-sm flex items-center dark:border-slate-800 dark:bg-slate-950/20 dark:text-slate-100">
+              <span *ngIf="editingSlug(); else slugHint" class="font-mono truncate">{{ editingSlug() }}</span>
+              <ng-template #slugHint>
+                <span class="text-slate-500 dark:text-slate-400">{{ 'adminUi.products.form.slugAutoHint' | translate }}</span>
+              </ng-template>
+            </div>
+          </div>
 
           <label class="grid gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
             {{ 'adminUi.products.table.category' | translate }}
@@ -503,7 +510,6 @@ export class AdminProductsComponent implements OnInit {
         const basePrice = typeof prod.base_price === 'number' ? prod.base_price : Number(prod.base_price || 0);
         this.form = {
           name: prod.name || '',
-          slug: prod.slug || slug,
           category_id: prod.category_id || '',
           base_price: Number.isFinite(basePrice) ? basePrice : 0,
           stock_quantity: Number(prod.stock_quantity || 0),
@@ -527,7 +533,6 @@ export class AdminProductsComponent implements OnInit {
   save(): void {
     const payload: any = {
       name: this.form.name,
-      slug: this.form.slug,
       category_id: this.form.category_id,
       base_price: Number(this.form.base_price),
       stock_quantity: Number(this.form.stock_quantity),
@@ -547,7 +552,7 @@ export class AdminProductsComponent implements OnInit {
       next: (prod: any) => {
         this.toast.success(this.t('adminUi.products.success.save'));
         this.editorMessage.set(this.t('adminUi.products.success.save'));
-        const newSlug = (prod?.slug as string | undefined) || this.form.slug || slug || null;
+        const newSlug = (prod?.slug as string | undefined) || slug || null;
         this.editingSlug.set(newSlug);
         this.images.set(Array.isArray(prod?.images) ? prod.images : this.images());
         if (newSlug) this.loadTranslations(newSlug);
@@ -688,7 +693,6 @@ export class AdminProductsComponent implements OnInit {
   private blankForm(): ProductForm {
     return {
       name: '',
-      slug: '',
       category_id: '',
       base_price: 0,
       stock_quantity: 0,

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -950,6 +950,7 @@
       },
       "form": {
         "slug": "Slug",
+        "slugAutoHint": "Auto-generated after save.",
         "sku": "SKU",
         "shortDescription": "Short description",
         "shortDescriptionHint": "Shown in product cards and listings (max 280 characters).",
@@ -978,7 +979,7 @@
         "load": "Unable to load product",
         "save": "Failed to save product",
         "delete": "Failed to delete product",
-        "required": "Category name and slug are required",
+        "required": "Category name is required",
         "image": "Image upload failed",
         "deleteImage": "Failed to delete image",
         "duplicate": "Could not duplicate product",
@@ -1009,6 +1010,7 @@
       "title": "Categories",
       "add": "Add category",
       "slug": "Slug",
+      "slugAutoHint": "Slug is auto-generated from the name.",
       "description": "Description",
       "translations": {
         "button": "Translations",

--- a/frontend/src/assets/i18n/ro.json
+++ b/frontend/src/assets/i18n/ro.json
@@ -950,6 +950,7 @@
       },
       "form": {
         "slug": "Slug",
+        "slugAutoHint": "Generat automat după salvare.",
         "sku": "SKU",
         "shortDescription": "Descriere scurtă",
         "shortDescriptionHint": "Apare în carduri și liste (max 280 caractere).",
@@ -978,7 +979,7 @@
         "load": "Nu am putut încărca produsul",
         "save": "Nu am putut salva produsul",
         "delete": "Nu am putut șterge produsul",
-        "required": "Numele și slug-ul categoriei sunt obligatorii",
+        "required": "Numele categoriei este obligatoriu",
         "image": "Încărcarea imaginii a eșuat",
         "deleteImage": "Nu am putut șterge imaginea",
         "duplicate": "Nu am putut duplica produsul",
@@ -1009,6 +1010,7 @@
       "title": "Categorii",
       "add": "Adaugă categorie",
       "slug": "Slug",
+      "slugAutoHint": "Slug-ul este generat automat din nume.",
       "description": "Descriere",
       "translations": {
         "button": "Traduceri",


### PR DESCRIPTION
**Summary**
- Removes manual slug management from admin workflows and hardens session restore so the UI doesn’t appear logged-in with an expired session.

**Changes**
- Backend: make `slug` optional on create for categories/products; enforce slug immutability; free product slugs on delete by tombstoning the deleted product slug and clearing `product_slug_history` entries.
- Admin UI: remove editable slug inputs for categories/products; show slug read-only with an auto-generated hint.
- Auth UX: add refresh-on-401 handling and clear stale sessions; revalidate the persisted session on app startup.
- Tests: add coverage for slug auto-generation + slug reuse after delete; keep slug-history redirect coverage by seeding a history row.

**Testing**
- `PYTHONPATH=backend ./.venv/bin/pytest backend/tests`
- `cd backend && ../.venv/bin/ruff check .`
- `cd backend && PYTHONPATH=$(pwd) ../.venv/bin/mypy app`
- `cd frontend && npm run lint`
- `cd frontend && CHROME_BIN=/usr/bin/chromium-browser npm test -- --watch=false --browsers=ChromeHeadless`
- `cd frontend && npm run build`

**Risk & Impact**
- Product slugs are now immutable; deleting a product frees its slug for reuse and removes its slug-history redirects.
- App boot performs an extra `/api/v1/auth/me` call when a session exists to prevent stale UI state.

**Related TODO items**
- `TODO.md`: auto-generate product/category slugs (admin UX) and free product slugs on delete.
- `TODO.md`: rephrase slug-related admin form item to reflect auto-generation.