### PR TITLE
Prefer exact PR head SHA when selecting deep-agent evidence run

### DIFF
--- a/.github/workflows/audit-pr-deep-agent.yml
+++ b/.github/workflows/audit-pr-deep-agent.yml
@@ -41,7 +41,7 @@ jobs:
               }
             }
 
-      - name: Resolve PR context and guard conditions
+      - name: Resolve PR context + latest evidence run
         id: guard
         uses: actions/github-script@v7
         with:
@@ -67,14 +67,17 @@ jobs:
             }
 
             const hasDeepLabel = (pr.labels || []).some((label) => label.name === 'audit:deep');
+            const prHeadSha = pr.head?.sha || '';
             core.setOutput('pr_number', String(pr.number));
             core.setOutput('pr_url', pr.html_url);
             core.setOutput('is_fork', pr.head?.repo?.fork ? 'true' : 'false');
             core.setOutput('has_deep_label', hasDeepLabel ? 'true' : 'false');
+            core.setOutput('pr_head_sha', prHeadSha);
             const shouldRun = context.eventName === 'workflow_dispatch' || hasDeepLabel;
             core.setOutput('should_run', shouldRun ? 'true' : 'false');
 
             let evidenceRunUrl = '';
+            let evidenceRunSha = '';
             try {
               const runs = await github.rest.actions.listWorkflowRuns({
                 owner,
@@ -86,13 +89,21 @@ jobs:
               });
               const matching = runs.data.workflow_runs.find((run) => {
                 if (run.conclusion !== 'success') return false;
+                if (run.head_sha !== prHeadSha) return false;
                 return (run.pull_requests || []).some((linked) => linked.number === pr.number);
               });
               evidenceRunUrl = matching?.html_url || '';
+              evidenceRunSha = matching?.head_sha || '';
+              if (evidenceRunUrl && evidenceRunSha) {
+                core.notice(`Selected evidence run for PR #${pr.number}: ${evidenceRunUrl} (head_sha: ${evidenceRunSha})`);
+              } else {
+                core.notice(`No successful Audit PR Evidence workflow run found for PR #${pr.number} at current head SHA ${prHeadSha}. Maintainers should rerun Audit PR Evidence.`);
+              }
             } catch (error) {
               core.notice(`Unable to resolve PR evidence run URL: ${error.message}`);
             }
             core.setOutput('evidence_run_url', evidenceRunUrl);
+            core.setOutput('evidence_run_sha', evidenceRunSha);
 
             if (context.eventName !== 'workflow_dispatch' && !hasDeepLabel) {
               core.notice('Skipping deep-agent flow: PR does not have audit:deep label.');


### PR DESCRIPTION
### Motivation
- Prevent the deep-audit flow from using stale evidence when a PR advances its head commit by anchoring evidence selection to the exact PR head SHA.
- Provide maintainers with clear traceability and guidance when no evidence run exists for the current PR head SHA.

### Description
- Capture `pr.head.sha` from the resolved PR payload and expose it as `pr_head_sha` output.
- When scanning `audit-pr-evidence.yml` runs, require both `run.conclusion === 'success'` and `run.head_sha === prHeadSha`, and still verify the run links to the same PR number.
- Emit workflow `core.notice` logs for traceability that include the selected run URL and matched SHA when found, or a clear rerun notice when no exact-sha successful run exists, and expose `evidence_run_sha` as output.

### Testing
- Applied the patch with `apply_patch` and verified the change was recorded in `.github/workflows/audit-pr-deep-agent.yml` using `git diff`, which succeeded.
- Verified repository state with `git status --short` and committed the change via `git commit -m "Prefer exact PR head SHA when selecting evidence run"`, which succeeded.
- Inspected the updated workflow file with `sed`/`nl` to confirm the new logic and notices were inserted, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a57307988332815f257538f28049)