### PR TITLE
Validate and safely default --max-routes in browser evidence collector

### DIFF
--- a/scripts/audit/collect_browser_evidence.max-routes.test.mjs
+++ b/scripts/audit/collect_browser_evidence.max-routes.test.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { resolveMaxRoutes } from "./collect_browser_evidence.mjs";
+
+const warnings = [];
+const logger = {
+  warn(message) {
+    warnings.push(String(message));
+  },
+};
+
+assert.equal(resolveMaxRoutes("foo", logger), 30);
+assert.equal(resolveMaxRoutes("0", logger), 30);
+assert.equal(resolveMaxRoutes("-3", logger), 30);
+assert.equal(resolveMaxRoutes("25", logger), 25);
+
+assert.deepEqual(warnings, [
+  'Invalid --max-routes value "foo"; defaulting to 30.',
+  'Invalid --max-routes value "0"; defaulting to 30.',
+  'Invalid --max-routes value "-3"; defaulting to 30.',
+]);
+
+process.stdout.write("collect_browser_evidence max-routes tests passed\n");


### PR DESCRIPTION
### Motivation
- Ensure the CLI option `--max-routes` is parsed robustly and cannot produce unexpected behavior when given invalid input. 
- Provide a safe sensible default for route sampling so downstream logic always receives a positive integer. 
- Make the script testable/importable without forcing Playwright to be installed when running small helper tests.

### Description
- Added `resolveMaxRoutes(value, logger = console)` which parses with `Number.parseInt(value, 10)` and assigns `maxRoutes = Number.isFinite(parsed) && parsed > 0 ? parsed : 30`.
- Emit a user-facing warning that includes the original token when an invalid `--max-routes` is supplied via `logger.warn`.
- Replaced inline parsing with `const maxRoutes = resolveMaxRoutes(args["max-routes"])` in `main` and moved the Playwright `require("@playwright/test")` into `main` so helpers can be imported without requiring Playwright.
- Guarded script entry with a direct-invocation check using `pathToFileURL(process.argv[1]).href` and exported `parseArgs` and `resolveMaxRoutes`; added a harness `scripts/audit/collect_browser_evidence.max-routes.test.mjs` to verify edge inputs.

### Testing
- Ran the harness with `node scripts/audit/collect_browser_evidence.max-routes.test.mjs` which passed and printed the success message. 
- Performed a static runtime check with `node --check scripts/audit/collect_browser_evidence.mjs && node --check scripts/audit/collect_browser_evidence.max-routes.test.mjs` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a571552c8332b7699ae45794e2d6)