### PR TITLE
Refactor route-map extraction to parse TypeScript route objects

### DIFF
--- a/scripts/audit/tests/fixtures/mixed_quotes_routes.ts
+++ b/scripts/audit/tests/fixtures/mixed_quotes_routes.ts
@@ -1,0 +1,46 @@
+import { Routes } from '@angular/router';
+
+export const routes: Routes = [
+  {
+    path: "",
+    title: 'routes.home.title',
+    data: {
+      robots: "index,follow",
+    },
+  },
+  {
+    path: 'account',
+    title:
+      "routes.account.title",
+    children: [
+      {
+        path: "orders",
+        title: 'routes.account.orders',
+        data: {
+          robots:
+            'noindex,nofollow',
+        },
+      },
+      {
+        path: 'settings',
+        title: getAccountTitle(),
+      },
+    ],
+  },
+  {
+    path: "admin",
+    children: [
+      {
+        path: 'content',
+        children: [
+          {
+            path: "pages",
+            title:
+              "routes.admin.content.pages",
+            robots: ROBOTS_NOINDEX,
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/scripts/audit/tests/test_extract_route_map.py
+++ b/scripts/audit/tests/test_extract_route_map.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[1] / "extract_route_map.py"
+    spec = importlib.util.spec_from_file_location("extract_route_map", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extract_route_map_handles_mixed_quotes_and_multiline_fields() -> None:
+    module = _load_module()
+    fixture = Path(__file__).resolve().parent / "fixtures" / "mixed_quotes_routes.ts"
+
+    route_map = module.extract_route_map(fixture)
+    routes = route_map["routes"]
+    by_path = {row["full_path"]: row for row in routes}
+
+    assert by_path["/"]["title_key"] == "routes.home.title"
+    assert by_path["/"]["robots_hint"] == "index,follow"
+
+    assert by_path["/account/orders"]["title_key"] == "routes.account.orders"
+    assert by_path["/account/orders"]["robots_hint"] == "noindex,nofollow"
+
+    assert by_path["/account/settings"]["title_key"] is None
+    assert by_path["/account/settings"]["robots_hint"] is None
+
+    assert by_path["/admin/content/pages"]["title_key"] == "routes.admin.content.pages"
+    assert by_path["/admin/content/pages"]["robots_hint"] == "ROBOTS_NOINDEX"
+
+
+def test_extract_route_map_sorting_semantics() -> None:
+    module = _load_module()
+    fixture = Path(__file__).resolve().parent / "fixtures" / "mixed_quotes_routes.ts"
+
+    route_map = module.extract_route_map(fixture)
+    routes = route_map["routes"]
+
+    assert routes == sorted(routes, key=lambda item: (item["surface"], item["full_path"]))


### PR DESCRIPTION
### Motivation
- Replace fragile regex-only scanning of `app.routes.ts` with a safer parser to correctly handle mixed quotes, multiline fields, comments, nested children and expression values.
- Ensure extraction preserves the existing route-map schema (`raw_path`, `prefix`, `full_path`, `surface`, `title_key`, `robots_hint`) and deterministic sort semantics.

### Description
- Replaced the `PATH_RE/TITLE_RE/ROBOTS_RE` approach in `scripts/audit/extract_route_map.py` with a token/bracket-aware TypeScript-like parser implemented in Python that reads arrays, objects, quoted strings, comments, and nested structures and returns parsed route dictionaries.
- Added helpers to read quoted strings, identifiers, consume expression values, and parse nested objects/arrays, and implemented `_collect_rows` to recursively build rows while preserving `prefix` and children traversal.
- Made fallback behavior explicit so non-literal titles are represented as `title_key=None` while robots hints are extracted from `robots` or `data.robots` (including expression values captured as string expressions).
- Added test fixture `scripts/audit/tests/fixtures/mixed_quotes_routes.ts` and test `scripts/audit/tests/test_extract_route_map.py` to validate mixed-quote styles, multiline fields, nested children, expression values, and sorting.

### Testing
- Ran `pytest -q scripts/audit/tests/test_extract_route_map.py` and the tests passed (`2 passed`).
- Ran Python compilation checks with `python -m py_compile scripts/audit/extract_route_map.py scripts/audit/tests/test_extract_route_map.py` and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a56f209483329b63ba62411a59b1)