### PR TITLE
Add pagination for audit issue dedupe lookups

### DIFF
--- a/scripts/audit/test_upsert_audit_issues_pagination.py
+++ b/scripts/audit/test_upsert_audit_issues_pagination.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+
+MODULE_PATH = Path(__file__).resolve().parent / "upsert_audit_issues.py"
+SPEC = importlib.util.spec_from_file_location("upsert_audit_issues", MODULE_PATH)
+assert SPEC and SPEC.loader
+upsert_audit_issues = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = upsert_audit_issues
+SPEC.loader.exec_module(upsert_audit_issues)
+
+
+GitHubContext = upsert_audit_issues.GitHubContext
+
+
+def test_upsert_severe_uses_paginated_open_issues_for_dedupe(monkeypatch):
+    ctx = GitHubContext(token="token", owner="octo", repo="demo")
+    finding = {
+        "fingerprint": "fp-page-2",
+        "severity": "s1",
+        "surface": "storefront",
+        "title": "Paged duplicate",
+        "labels": ["audit:test"],
+    }
+
+    page_1_rows = [{"number": i, "title": f"Issue {i}"} for i in range(1, 101)]
+    # Keep PR filtering behavior intact by ensuring PR rows do not become dedupe candidates.
+    page_1_rows[0]["pull_request"] = {"url": "https://api.github.com/repos/octo/demo/pulls/1"}
+    page_2_rows = [
+        {
+            "number": 999,
+            "title": "Existing paged finding",
+            "body": "<!-- audit:fingerprint:fp-page-2 -->\n\nOld body",
+        }
+    ]
+
+    patch_calls: list[tuple[str, dict[str, object]]] = []
+    post_calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_request(_ctx, method, path, payload=None):
+        if method == "GET" and path.startswith("/repos/octo/demo/issues?"):
+            query = parse_qs(urlparse(path).query)
+            page = query.get("page", ["1"])[0]
+            if page == "1":
+                return page_1_rows
+            if page == "2":
+                return page_2_rows
+            return []
+        if method == "PATCH":
+            patch_calls.append((path, payload or {}))
+            return {"number": 999}
+        if method == "POST":
+            post_calls.append((path, payload or {}))
+            return {"number": 1234}
+        raise AssertionError(f"Unexpected call: {method} {path}")
+
+    monkeypatch.setattr(upsert_audit_issues, "_request", fake_request)
+
+    upsert_audit_issues._upsert_severe(ctx, [finding], run_url=None)
+
+    assert post_calls == []
+    assert len(patch_calls) == 1
+    assert patch_calls[0][0].endswith("/issues/999")


### PR DESCRIPTION
### Motivation

- The GitHub issues lookup previously fetched only a single page of open issues, which could miss existing issues on later pages and cause duplicate upserts.
- Both severe and digest upsert paths need the same paginated lookup so dedupe works consistently across all upsert flows.

### Description

- Implemented page-based iteration in `_list_open_issues()` to request `page=1..N` with `per_page=100` and stop when a page returns fewer than `per_page` items. 
- Preserved existing behavior by continuing to filter out pull requests (`"pull_request" not in row`) when aggregating results.
- Both `_upsert_severe` and `_upsert_digest` now reuse the same paginated `_list_open_issues()` helper so all upsert paths benefit from pagination.
- Added a unit-style test at `scripts/audit/test_upsert_audit_issues_pagination.py` that mocks paged API responses and verifies an existing issue on page 2 is detected for dedupe (resulting in a `PATCH` instead of a `POST`).

### Testing

- Ran `pytest -q scripts/audit/test_upsert_audit_issues_pagination.py`, which executed the new pagination test and passed (`1 passed`).
- The changed file is `scripts/audit/upsert_audit_issues.py` and the new test file is `scripts/audit/test_upsert_audit_issues_pagination.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a56c0ed88332b8e70a43ef1e5247)