### PR TITLE
Strengthen media-worker healthchecks with Redis and stale-job guards

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -101,7 +101,7 @@ services:
           "CMD",
           "python",
           "-c",
-          "import pathlib,time,sys; p=pathlib.Path('/tmp/media-worker-heartbeat.json'); sys.exit(0 if p.exists() and (time.time()-p.stat().st_mtime) < 90 else 1)",
+          "import asyncio,os,pathlib,socket,sys,time,urllib.parse; HEARTBEAT_MAX_AGE_SECONDS=90; EXIT_HEARTBEAT=11; EXIT_REDIS=12; EXIT_STALE=13; EXIT_DB=14; p=pathlib.Path('/tmp/media-worker-heartbeat.json'); now=time.time(); sys.exit(EXIT_HEARTBEAT) if (not p.exists() or (now-p.stat().st_mtime)>=HEARTBEAT_MAX_AGE_SECONDS) else None; redis_url=(os.getenv('REDIS_URL') or '').strip();\nif redis_url:\n u=urllib.parse.urlparse(redis_url); host=u.hostname; port=u.port or 6379;\n if not host: sys.exit(EXIT_REDIS);\n try:\n  with socket.create_connection((host,port), timeout=1.5) as s:\n   s.settimeout(1.5); s.sendall(b'*1\\r\\n$4\\r\\nPING\\r\\n');\n   if b'PONG' not in s.recv(64): sys.exit(EXIT_REDIS);\n except Exception:\n  sys.exit(EXIT_REDIS);\nasync def check_db():\n stale=max(60, int(os.getenv('MEDIA_DAM_PROCESSING_STALE_SECONDS','600') or '600')); db_url=(os.getenv('DATABASE_URL') or '').replace('+asyncpg','');\n if not db_url: raise RuntimeError('DATABASE_URL is required');\n import asyncpg\n conn=await asyncpg.connect(db_url, timeout=2, command_timeout=2)\n try:\n  return int(await conn.fetchval(\"select count(*) from media_jobs where status='processing' and started_at < (now() - make_interval(secs => $1::int))\", stale) or 0)\n finally:\n  await conn.close()\ntry:\n stale_count=asyncio.run(asyncio.wait_for(check_db(), timeout=3.5))\nexcept SystemExit: raise\nexcept Exception:\n sys.exit(EXIT_DB)\nsys.exit(EXIT_STALE if stale_count > 0 else 0)",
         ]
       interval: 10s
       timeout: 5s

--- a/infra/prod/README.md
+++ b/infra/prod/README.md
@@ -81,6 +81,7 @@ Notes:
 - After a VPS reboot, the stack starts automatically (`restart: unless-stopped`). You usually **do not** need to run `deploy.sh` again.
 - By default, `deploy.sh` exports `APP_VERSION=$(git rev-parse --short HEAD)` before recreating containers so backend/frontend diagnostics show the deployed revision.
 - `deploy.sh` waits for `media-worker` heartbeat health before running post-sync checks. If the worker is unhealthy, deploy exits non-zero and prints worker logs.
+- `media-worker` health now validates four signals: fresh heartbeat file (<90s), optional Redis connectivity when `REDIS_URL` is set, DB connectivity, and zero `media_jobs` stuck in `processing` longer than `MEDIA_DAM_PROCESSING_STALE_SECONDS` (min 60s). Distinct exits are used for diagnosis: `11` heartbeat stale/missing, `12` Redis probe failed, `13` stale processing jobs detected, `14` DB probe/query failed.
 - `deploy.sh` runs `infra/prod/verify-live.sh` after startup. Set `RUN_POST_SYNC_VERIFY=0` to skip that step.
 - `deploy.sh` can print a Search Console URL Inspection checklist for key URLs (home/shop/blog/product). Set `RUN_GSC_INDEXING_CHECKLIST=0` to skip it.
 

--- a/infra/prod/docker-compose.yml
+++ b/infra/prod/docker-compose.yml
@@ -121,7 +121,7 @@ services:
           "CMD",
           "python",
           "-c",
-          "import pathlib,time,sys; p=pathlib.Path('/tmp/media-worker-heartbeat.json'); sys.exit(0 if p.exists() and (time.time()-p.stat().st_mtime) < 90 else 1)",
+          "import asyncio,os,pathlib,socket,sys,time,urllib.parse; HEARTBEAT_MAX_AGE_SECONDS=90; EXIT_HEARTBEAT=11; EXIT_REDIS=12; EXIT_STALE=13; EXIT_DB=14; p=pathlib.Path('/tmp/media-worker-heartbeat.json'); now=time.time(); sys.exit(EXIT_HEARTBEAT) if (not p.exists() or (now-p.stat().st_mtime)>=HEARTBEAT_MAX_AGE_SECONDS) else None; redis_url=(os.getenv('REDIS_URL') or '').strip();\nif redis_url:\n u=urllib.parse.urlparse(redis_url); host=u.hostname; port=u.port or 6379;\n if not host: sys.exit(EXIT_REDIS);\n try:\n  with socket.create_connection((host,port), timeout=1.5) as s:\n   s.settimeout(1.5); s.sendall(b'*1\\r\\n$4\\r\\nPING\\r\\n');\n   if b'PONG' not in s.recv(64): sys.exit(EXIT_REDIS);\n except Exception:\n  sys.exit(EXIT_REDIS);\nasync def check_db():\n stale=max(60, int(os.getenv('MEDIA_DAM_PROCESSING_STALE_SECONDS','600') or '600')); db_url=(os.getenv('DATABASE_URL') or '').replace('+asyncpg','');\n if not db_url: raise RuntimeError('DATABASE_URL is required');\n import asyncpg\n conn=await asyncpg.connect(db_url, timeout=2, command_timeout=2)\n try:\n  return int(await conn.fetchval(\"select count(*) from media_jobs where status='processing' and started_at < (now() - make_interval(secs => $1::int))\", stale) or 0)\n finally:\n  await conn.close()\ntry:\n stale_count=asyncio.run(asyncio.wait_for(check_db(), timeout=3.5))\nexcept SystemExit: raise\nexcept Exception:\n sys.exit(EXIT_DB)\nsys.exit(EXIT_STALE if stale_count > 0 else 0)",
         ]
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
### Motivation
- Keep the existing heartbeat freshness check (<90s) but make the worker healthcheck a stronger signal by verifying Redis connectivity when configured and ensuring no media jobs are stuck in `processing` beyond a stale threshold. 
- Provide distinct, deterministic exit codes so orchestrators/operators can quickly triage which signal failed. 
- Keep probes fast (<5s) and conservative to avoid health flapping on transient issues.

### Description
- Replaced the inline healthcheck in `infra/docker-compose.yml` and `infra/prod/docker-compose.yml` for `media-worker` with a compact Python probe that preserves the heartbeat-file check and adds optional Redis and DB/stale-job assertions. 
- Redis check is conditional on `REDIS_URL` and uses a lightweight TCP RESP `PING` probe with tight timeouts to avoid blocking. 
- DB stale-processing guard queries `media_jobs` for rows with `status='processing'` older than `MEDIA_DAM_PROCESSING_STALE_SECONDS` (minimum 60s) via `asyncpg` inside an `asyncio` timeout; the probe fails if any stale jobs are found. 
- Documented the new health semantics and exit-code mapping in `infra/prod/README.md` (exit `11` heartbeat stale/missing, `12` Redis probe failed, `13` stale processing jobs detected, `14` DB probe/query failed).

### Testing
- Attempted to validate the composed config with `docker compose -f infra/docker-compose.yml config`, but this check failed in the environment because the Docker CLI is unavailable (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a565fca883328598c68aa5b7b215)