### PR TITLE
Add degraded-mode DB polling fallback for media worker

### DIFF
--- a/backend/app/workers/media_worker.py
+++ b/backend/app/workers/media_worker.py
@@ -13,9 +13,12 @@ from pathlib import Path
 from typing import TypeVar, cast
 from uuid import UUID, uuid4
 
+from sqlalchemy import select
+
 from app.core.config import settings
 from app.core.redis_client import get_redis
 from app.db.session import SessionLocal
+from app.models.media import MediaJob, MediaJobStatus
 from app.services import media_dam
 
 
@@ -26,6 +29,9 @@ HEARTBEAT_PREFIX = str(getattr(settings, "media_dam_worker_heartbeat_prefix", "m
 HEARTBEAT_TTL_SECONDS = max(10, int(getattr(settings, "media_dam_worker_heartbeat_ttl_seconds", 30) or 30))
 HEARTBEAT_FILE = str(getattr(settings, "media_dam_worker_heartbeat_file", "/tmp/media-worker-heartbeat.json") or "/tmp/media-worker-heartbeat.json")
 RETRY_SWEEP_SECONDS = max(5, int(getattr(settings, "media_dam_retry_sweep_seconds", 10) or 10))
+FALLBACK_JOB_BATCH_SIZE = max(1, int(getattr(settings, "media_dam_fallback_job_batch_size", 10) or 10))
+FALLBACK_STATS_LOG_SECONDS = max(5, int(getattr(settings, "media_dam_fallback_stats_log_seconds", 30) or 30))
+FALLBACK_MAX_SLEEP_SECONDS = max(1.0, float(getattr(settings, "media_dam_fallback_max_sleep_seconds", 5.0) or 5.0))
 
 
 async def _process_job_id(raw_job_id: str) -> None:
@@ -41,14 +47,35 @@ async def _process_job_id(raw_job_id: str) -> None:
             logger.exception("media_worker_job_failed", extra={"job_id": str(job_id)})
 
 
-async def _enqueue_due_retries_once(limit: int = 50) -> None:
+async def _enqueue_due_retries_once(limit: int = 50) -> int:
     async with SessionLocal() as session:
         try:
             queued = await media_dam.enqueue_due_retries(session, limit=limit)
             if queued:
                 logger.info("media_worker_retry_enqueued", extra={"count": len(queued)})
+            return len(queued)
         except Exception:
             logger.exception("media_worker_retry_sweep_failed")
+            return 0
+
+
+async def _process_queued_jobs_once(limit: int = FALLBACK_JOB_BATCH_SIZE) -> int:
+    async with SessionLocal() as session:
+        rows = await session.execute(
+            select(MediaJob)
+            .where(MediaJob.status == MediaJobStatus.queued)
+            .order_by(MediaJob.created_at.asc())
+            .limit(max(1, min(int(limit or 1), 500)))
+        )
+        jobs = rows.scalars().all()
+        processed_count = 0
+        for job in jobs:
+            try:
+                await media_dam.process_job_inline(session, job)
+                processed_count += 1
+            except Exception:
+                logger.exception("media_worker_fallback_job_failed", extra={"job_id": str(job.id)})
+        return processed_count
 
 
 def _worker_id() -> str:
@@ -89,11 +116,48 @@ async def run_media_worker(poll_interval_seconds: float = 2.0) -> None:
     redis = get_redis()
     worker_id = _worker_id()
     heartbeat_interval = max(5.0, float(HEARTBEAT_TTL_SECONDS) / 2.0)
+    bounded_sleep = min(FALLBACK_MAX_SLEEP_SECONDS, max(0.1, float(poll_interval_seconds)))
     if redis is None:
-        logger.warning("media_worker_no_redis")
+        logger.warning(
+            "media_worker_degraded_mode_started",
+            extra={
+                "worker_id": worker_id,
+                "poll_interval_seconds": bounded_sleep,
+                "retry_sweep_seconds": float(RETRY_SWEEP_SECONDS),
+                "job_batch_size": int(FALLBACK_JOB_BATCH_SIZE),
+            },
+        )
+        last_heartbeat = 0.0
+        last_retry_sweep = 0.0
+        last_stats_log = 0.0
+        processed_count = 0
+        retry_enqueued_count = 0
         while True:
-            await _publish_heartbeat(None, worker_id=worker_id)
-            await asyncio.sleep(max(0.1, poll_interval_seconds))
+            try:
+                now = time.monotonic()
+                if now - last_heartbeat >= heartbeat_interval:
+                    await _publish_heartbeat(None, worker_id=worker_id)
+                    last_heartbeat = now
+                if now - last_retry_sweep >= float(RETRY_SWEEP_SECONDS):
+                    retry_enqueued_count += await _enqueue_due_retries_once(limit=100)
+                    last_retry_sweep = now
+                processed_count += await _process_queued_jobs_once(limit=FALLBACK_JOB_BATCH_SIZE)
+                if now - last_stats_log >= float(FALLBACK_STATS_LOG_SECONDS):
+                    logger.warning(
+                        "media_worker_degraded_mode_stats",
+                        extra={
+                            "worker_id": worker_id,
+                            "processed_count": processed_count,
+                            "retry_enqueued_count": retry_enqueued_count,
+                        },
+                    )
+                    last_stats_log = now
+                await asyncio.sleep(bounded_sleep)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("media_worker_degraded_mode_loop_error", extra={"worker_id": worker_id})
+                await asyncio.sleep(bounded_sleep)
     logger.info("media_worker_started")
     last_heartbeat = 0.0
     last_retry_sweep = 0.0

--- a/backend/tests/test_media_worker.py
+++ b/backend/tests/test_media_worker.py
@@ -1,0 +1,80 @@
+import asyncio
+import logging
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.db.base import Base
+from app.models.media import MediaJob, MediaJobStatus, MediaJobType
+from app.workers import media_worker
+
+
+@pytest.mark.anyio("asyncio")
+async def test_process_queued_jobs_once_advances_jobs_without_redis(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    test_session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    monkeypatch.setattr(media_worker, "SessionLocal", test_session_factory)
+
+    async with test_session_factory() as session:
+        job = MediaJob(job_type=MediaJobType.usage_reconcile, status=MediaJobStatus.queued, payload_json="{}")
+        session.add(job)
+        await session.commit()
+        job_id = job.id
+
+    async def _fake_process_job_inline(session, job):
+        job.status = MediaJobStatus.completed
+        session.add(job)
+        await session.commit()
+        return job
+
+    monkeypatch.setattr(media_worker.media_dam, "process_job_inline", _fake_process_job_inline)
+
+    processed_count = await media_worker._process_queued_jobs_once(limit=10)
+    assert processed_count == 1
+
+    async with test_session_factory() as session:
+        refreshed = await session.scalar(select(MediaJob).where(MediaJob.id == job_id))
+        assert refreshed is not None
+        assert refreshed.status == MediaJobStatus.completed
+
+
+@pytest.mark.anyio("asyncio")
+async def test_run_media_worker_fallback_runs_retries_and_logs(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    calls = {"retry": 0, "process": 0, "heartbeat": 0, "sleep": 0}
+
+    monkeypatch.setattr(media_worker, "get_redis", lambda: None)
+
+    async def _fake_heartbeat(_redis, *, worker_id: str):
+        calls["heartbeat"] += 1
+
+    async def _fake_enqueue(*, limit: int = 50) -> int:
+        calls["retry"] += 1
+        return 2
+
+    async def _fake_process(*, limit: int = media_worker.FALLBACK_JOB_BATCH_SIZE) -> int:
+        calls["process"] += 1
+        return 1
+
+    async def _fake_sleep(_seconds: float) -> None:
+        calls["sleep"] += 1
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(media_worker, "_publish_heartbeat", _fake_heartbeat)
+    monkeypatch.setattr(media_worker, "_enqueue_due_retries_once", _fake_enqueue)
+    monkeypatch.setattr(media_worker, "_process_queued_jobs_once", _fake_process)
+    monkeypatch.setattr(media_worker.asyncio, "sleep", _fake_sleep)
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(asyncio.CancelledError):
+            await media_worker.run_media_worker(poll_interval_seconds=0.01)
+
+    assert calls["heartbeat"] >= 1
+    assert calls["retry"] >= 1
+    assert calls["process"] >= 1
+    assert calls["sleep"] >= 1
+    assert "media_worker_degraded_mode_started" in caplog.text
+    assert "media_worker_degraded_mode_stats" in caplog.text


### PR DESCRIPTION
### Motivation
- Ensure the media worker can process queued `MediaJob` rows when Redis is not configured so work continues in degraded environments.
- Run the retry enqueue sweep in fallback mode to mirror Redis-mode behavior and avoid lost retries.
- Emit structured warning logs so operators can detect and monitor degraded-mode activity and throughput.

### Description
- Added fallback configuration and constants: `FALLBACK_JOB_BATCH_SIZE`, `FALLBACK_STATS_LOG_SECONDS`, and `FALLBACK_MAX_SLEEP_SECONDS` and a bounded `bounded_sleep` for the fallback loop.
- Implemented `_process_queued_jobs_once` which selects `MediaJob.status == queued` and calls `media_dam.process_job_inline(...)` for each job.
- Changed `_enqueue_due_retries_once` to return an integer count and wired it into the degraded loop so retries are enqueued on a timer in fallback mode as well.
- Reworked the `redis is None` path inside `run_media_worker` to perform heartbeat publishing, retry sweeps, DB job processing, periodic structured warning logs (`media_worker_degraded_mode_started` and `media_worker_degraded_mode_stats`), bounded sleeps, and loop-level exception handling consistent with the Redis loop.
- Added tests in `backend/tests/test_media_worker.py` covering the no-Redis path and degraded-mode loop interactions.

### Testing
- Added `backend/tests/test_media_worker.py` with two async tests: `test_process_queued_jobs_once_advances_jobs_without_redis` and `test_run_media_worker_fallback_runs_retries_and_logs`.
- `PYTHONPATH=. pytest -q tests/test_media_worker.py` ran the new tests and succeeded with `2 passed`.
- Running `pytest` without setting `PYTHONPATH` initially failed to import the application package (`ModuleNotFoundError`) which was resolved by invoking tests with `PYTHONPATH=.`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a564087883328c62cd6c14bba7f0)