### PR TITLE
Adjust webhook backlog semantics to expose total and recent pending counts

### DIFF
--- a/backend/app/api/v1/ops.py
+++ b/backend/app/api/v1/ops.py
@@ -143,7 +143,8 @@ async def admin_webhook_backlog_stats(
     since_hours: int = Query(default=24, ge=1, le=168),
 ) -> WebhookBacklogCount:
     pending = await ops_service.count_webhook_backlog(session, since_hours=since_hours)
-    return WebhookBacklogCount(pending=pending, since_hours=int(since_hours))
+    pending_recent = await ops_service.count_recent_webhook_backlog(session, since_hours=since_hours)
+    return WebhookBacklogCount(pending=pending, pending_recent=pending_recent, since_hours=int(since_hours))
 
 
 @router.get("/admin/webhooks/{provider}/{event_id}", response_model=WebhookEventDetail)

--- a/backend/app/schemas/ops.py
+++ b/backend/app/schemas/ops.py
@@ -144,6 +144,7 @@ class FailureCount(BaseModel):
 
 class WebhookBacklogCount(BaseModel):
     pending: int = 0
+    pending_recent: int = 0
     since_hours: int
 
 

--- a/backend/app/services/ops.py
+++ b/backend/app/services/ops.py
@@ -305,11 +305,33 @@ async def count_failed_webhooks(session: AsyncSession, *, since_hours: int = 24)
 
 
 async def count_webhook_backlog(session: AsyncSession, *, since_hours: int = 24) -> int:
+    _ = since_hours
+
+    stripe_pending_total = await session.scalar(
+        select(func.count())
+        .select_from(StripeWebhookEvent)
+        .where(
+            StripeWebhookEvent.processed_at.is_(None),
+            or_(StripeWebhookEvent.last_error.is_(None), StripeWebhookEvent.last_error == ""),
+        )
+    )
+    paypal_pending_total = await session.scalar(
+        select(func.count())
+        .select_from(PayPalWebhookEvent)
+        .where(
+            PayPalWebhookEvent.processed_at.is_(None),
+            or_(PayPalWebhookEvent.last_error.is_(None), PayPalWebhookEvent.last_error == ""),
+        )
+    )
+    return int(stripe_pending_total or 0) + int(paypal_pending_total or 0)
+
+
+async def count_recent_webhook_backlog(session: AsyncSession, *, since_hours: int = 24) -> int:
     now = datetime.now(timezone.utc)
     hours = max(1, int(since_hours or 0))
     since = now - timedelta(hours=hours)
 
-    stripe_pending = await session.scalar(
+    stripe_pending_recent = await session.scalar(
         select(func.count())
         .select_from(StripeWebhookEvent)
         .where(
@@ -318,7 +340,7 @@ async def count_webhook_backlog(session: AsyncSession, *, since_hours: int = 24)
             StripeWebhookEvent.last_attempt_at >= since,
         )
     )
-    paypal_pending = await session.scalar(
+    paypal_pending_recent = await session.scalar(
         select(func.count())
         .select_from(PayPalWebhookEvent)
         .where(
@@ -327,7 +349,7 @@ async def count_webhook_backlog(session: AsyncSession, *, since_hours: int = 24)
             PayPalWebhookEvent.last_attempt_at >= since,
         )
     )
-    return int(stripe_pending or 0) + int(paypal_pending or 0)
+    return int(stripe_pending_recent or 0) + int(paypal_pending_recent or 0)
 
 
 async def list_email_failures(

--- a/frontend/src/app/core/ops.service.ts
+++ b/frontend/src/app/core/ops.service.ts
@@ -93,6 +93,7 @@ export interface FailureCount {
 
 export interface WebhookBacklogCount {
   pending: number;
+  pending_recent: number;
   since_hours: number;
 }
 

--- a/frontend/src/app/pages/admin/ops/admin-ops.component.ts
+++ b/frontend/src/app/pages/admin/ops/admin-ops.component.ts
@@ -63,7 +63,7 @@ import { AdminPageHeaderComponent } from '../shared/admin-page-header.component'
             {{ healthError() }}
           </div>
 
-          <div *ngIf="!healthLoading()" class="grid gap-3 md:grid-cols-4">
+          <div *ngIf="!healthLoading()" class="grid gap-3 md:grid-cols-5">
             <div class="rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-950/20">
               <p class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
                 {{ 'adminUi.ops.health.backend' | translate }}
@@ -87,9 +87,18 @@ import { AdminPageHeaderComponent } from '../shared/admin-page-header.component'
 
             <div class="rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-950/20">
               <p class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                {{ 'adminUi.ops.health.webhooksBacklog' | translate }}
+                {{ 'adminUi.ops.health.webhooksBacklogTotal' | translate }}
               </p>
-              <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-slate-50">{{ webhookBacklog24h() }}</p>
+              <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-slate-50">{{ webhookBacklogTotal() }}</p>
+              <p class="mt-1 text-xs text-slate-600 dark:text-slate-300">{{ 'adminUi.ops.health.totalPendingHint' | translate }}</p>
+            </div>
+
+
+            <div class="rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-950/20">
+              <p class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                {{ 'adminUi.ops.health.webhooksBacklogRecent' | translate }}
+              </p>
+              <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-slate-50">{{ webhookBacklogRecent24h() }}</p>
               <p class="mt-1 text-xs text-slate-600 dark:text-slate-300">{{ 'adminUi.ops.health.lastHours' | translate: { hours: 24 } }}</p>
             </div>
 
@@ -926,7 +935,8 @@ export class AdminOpsComponent implements OnInit {
   healthError = signal<string | null>(null);
   backendReady = signal(false);
   webhookFailures24h = signal(0);
-  webhookBacklog24h = signal(0);
+  webhookBacklogTotal = signal(0);
+  webhookBacklogRecent24h = signal(0);
   emailFailures24h = signal(0);
   healthCheckedAt = signal<Date | null>(null);
   newsletterExporting = signal(false);
@@ -1025,8 +1035,10 @@ export class AdminOpsComponent implements OnInit {
           this.webhookFailures24h.set(Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0);
         }
         if (res.webhooksBacklog) {
-          const count = Number((res.webhooksBacklog as any)?.pending ?? 0);
-          this.webhookBacklog24h.set(Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0);
+          const totalCount = Number((res.webhooksBacklog as any)?.pending ?? 0);
+          const recentCount = Number((res.webhooksBacklog as any)?.pending_recent ?? 0);
+          this.webhookBacklogTotal.set(Number.isFinite(totalCount) ? Math.max(0, Math.floor(totalCount)) : 0);
+          this.webhookBacklogRecent24h.set(Number.isFinite(recentCount) ? Math.max(0, Math.floor(recentCount)) : 0);
         }
         if (res.emailsFailed) {
           const count = Number((res.emailsFailed as any)?.failed ?? 0);

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -2432,7 +2432,10 @@
         "backend": "Backend (DB ready)",
         "webhooksFailed": "Webhook failures",
         "webhooksBacklog": "Webhook backlog",
+        "webhooksBacklogTotal": "Webhook pending (total)",
+        "webhooksBacklogRecent": "Webhook pending (recent)",
         "emailFailures": "Email failures",
+        "totalPendingHint": "Total pending across all time",
         "lastHours": "Last {{hours}}h",
         "lastChecked": "Last checked",
         "errors": {

--- a/frontend/src/assets/i18n/ro.json
+++ b/frontend/src/assets/i18n/ro.json
@@ -2432,7 +2432,10 @@
         "backend": "Backend (DB gata)",
         "webhooksFailed": "Webhook-uri eșuate",
         "webhooksBacklog": "Backlog webhook",
+        "webhooksBacklogTotal": "Webhook în așteptare (total)",
+        "webhooksBacklogRecent": "Webhook în așteptare (recent)",
         "emailFailures": "Email-uri eșuate",
+        "totalPendingHint": "Total în așteptare pe toată perioada",
         "lastHours": "Ultimele {{hours}}h",
         "lastChecked": "Ultima verificare",
         "errors": {


### PR DESCRIPTION
### Motivation
- The existing webhook backlog metric mixed a time-window filter into the notion of backlog, hiding old unprocessed records from the “backlog” count; operators need both the absolute total pending and a recent-window view.

### Description
- Change `count_webhook_backlog` to return total pending rows (unprocessed, no error) without applying the `since_hours` filter in `backend/app/services/ops.py`.
- Add `count_recent_webhook_backlog` which preserves the windowed semantics (`since_hours`) for recent pending counts, and wire both metrics into the `/ops/admin/webhooks/backlog` endpoint in `backend/app/api/v1/ops.py`.
- Extend the `WebhookBacklogCount` schema with `pending_recent` in `backend/app/schemas/ops.py`, update tests to seed old/recent pending rows and assert both metrics in `backend/tests/test_ops_api.py`, and update frontend typings and UI to show separate “total pending” and “recent pending” cards (`frontend/src/app/core/ops.service.ts` and `frontend/src/app/pages/admin/ops/admin-ops.component.ts`).
- Add small i18n label/hint updates for both English and Romanian to clarify the two backlog metrics (`frontend/src/assets/i18n/*.json`).

### Testing
- Ran the ops API unit tests with `PYTHONPATH=. pytest -q tests/test_ops_api.py` and the suite passed (2 tests, all passed).
- Attempted an automated Playwright UI capture of the admin ops page, but the local frontend endpoint returned `ERR_EMPTY_RESPONSE` in this environment (screenshot run failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a55169e88332ba402c872a7f8313)