### PR TITLE
fix: stabilize weekly/deep audit agent orchestration

### DIFF
--- a/.github/workflows/audit-pr-deep-agent.yml
+++ b/.github/workflows/audit-pr-deep-agent.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       pr_number:
         description: "PR number to run deep audit issue flow for"
-        required: true
+        required: false
         type: string
 
 permissions:
@@ -50,13 +50,49 @@ jobs:
             let pr = null;
 
             if (context.eventName === 'workflow_dispatch') {
-              const number = Number(core.getInput('pr_number') || 0);
-              if (!number) {
-                core.setFailed('workflow_dispatch requires pr_number input.');
+              const rawNumber = (core.getInput('pr_number') || '').trim();
+              const parsedNumber = rawNumber ? Number(rawNumber) : 0;
+              if (rawNumber && (!Number.isInteger(parsedNumber) || parsedNumber <= 0)) {
+                core.setFailed(
+                  `Invalid pr_number input: "${rawNumber}". ` +
+                  'Use a positive integer. Example: gh workflow run "Audit PR Deep Agent" -f pr_number=207'
+                );
                 return;
               }
-              const fetched = await github.rest.pulls.get({ owner, repo, pull_number: number });
-              pr = fetched.data;
+
+              if (parsedNumber) {
+                const fetched = await github.rest.pulls.get({ owner, repo, pull_number: parsedNumber });
+                pr = fetched.data;
+              } else {
+                const openPulls = await github.paginate(github.rest.pulls.list, {
+                  owner,
+                  repo,
+                  state: 'open',
+                  base: 'main',
+                  per_page: 100,
+                });
+                if (openPulls.length === 1) {
+                  pr = openPulls[0];
+                  core.notice(`workflow_dispatch auto-selected PR #${pr.number}.`);
+                } else if (openPulls.length === 0) {
+                  core.setFailed(
+                    'No open PR targeting main was found for workflow_dispatch auto-detect. ' +
+                    'Open a PR first or re-run with -f pr_number=<number>.'
+                  );
+                  return;
+                } else {
+                  const candidates = openPulls
+                    .slice(0, 15)
+                    .map((candidate) => `#${candidate.number} (${candidate.head?.ref || 'unknown'} -> ${candidate.base?.ref || 'main'})`)
+                    .join(', ');
+                  core.setFailed(
+                    'Multiple open PRs target main; cannot auto-select safely. ' +
+                    `Candidates: ${candidates}. ` +
+                    'Re-run with an explicit value, e.g. gh workflow run "Audit PR Deep Agent" -f pr_number=<number>.'
+                  );
+                  return;
+                }
+              }
             } else {
               pr = context.payload.pull_request;
             }
@@ -73,6 +109,7 @@ jobs:
             core.setOutput('has_deep_label', hasDeepLabel ? 'true' : 'false');
             const shouldRun = context.eventName === 'workflow_dispatch' || hasDeepLabel;
             core.setOutput('should_run', shouldRun ? 'true' : 'false');
+            core.setOutput('resolution_mode', context.eventName === 'workflow_dispatch' ? 'manual' : 'pull_request_target');
 
             let evidenceRunUrl = '';
             try {
@@ -218,3 +255,36 @@ jobs:
                 body: 'Automatic @copilot assignment failed. Maintainer can run: `gh issue edit ' + issueNumber + ' --add-assignee @copilot`.',
               });
             }
+
+      - name: Deep agent summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          pr_number="${{ steps.guard.outputs.pr_number }}"
+          pr_url="${{ steps.guard.outputs.pr_url }}"
+          should_run="${{ steps.guard.outputs.should_run }}"
+          evidence_url="${{ steps.guard.outputs.evidence_run_url }}"
+          resolution_mode="${{ steps.guard.outputs.resolution_mode }}"
+          issue_number="${{ steps.issue.outputs.issue_number }}"
+
+          {
+            echo "## Deep Agent Summary"
+            echo ""
+            echo "- Trigger event: \`${{ github.event_name }}\`"
+            echo "- Resolution mode: \`${resolution_mode:-unknown}\`"
+            if [[ -n "${pr_number}" ]]; then
+              echo "- PR: #${pr_number} (${pr_url})"
+            fi
+            if [[ -n "${evidence_url}" ]]; then
+              echo "- PR evidence run: ${evidence_url}"
+            fi
+            if [[ -z "${should_run}" ]]; then
+              echo "- Outcome: failed during PR context resolution"
+            elif [[ "${should_run}" == "true" ]]; then
+              echo "- Outcome: processed"
+              echo "- Deep issue number: \`${issue_number:-n/a}\`"
+            else
+              echo "- Outcome: skipped (missing \`audit:deep\` label on PR-triggered path)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/audit-weekly-agent.yml
+++ b/.github/workflows/audit-weekly-agent.yml
@@ -3,6 +3,9 @@ name: Audit Weekly Agent
 on:
   schedule:
     - cron: "45 4 * * 1"
+  workflow_run:
+    workflows: ["Audit Weekly Evidence"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -14,6 +17,9 @@ permissions:
 jobs:
   audit-weekly-agent:
     runs-on: ubuntu-latest
+    concurrency:
+      group: audit-weekly-agent-main
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -50,22 +56,50 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
+            if (context.eventName === 'workflow_run') {
+              const sourceRun = context.payload.workflow_run;
+              if (!sourceRun) {
+                core.setFailed('Missing workflow_run payload.');
+                return;
+              }
+              if (sourceRun.conclusion !== 'success') {
+                const reason = `Source run completed with conclusion=${sourceRun.conclusion}.`;
+                core.notice(reason);
+                core.setOutput('skip_followup', 'true');
+                core.setOutput('skip_reason', reason);
+                core.setOutput('source_trigger', 'workflow_run');
+                return;
+              }
+              core.setOutput('run_id', String(sourceRun.id));
+              core.setOutput('run_url', sourceRun.html_url || '');
+              core.setOutput('skip_followup', 'false');
+              core.setOutput('source_trigger', 'workflow_run');
+              return;
+            }
+
             const runs = await github.rest.actions.listWorkflowRuns({
               owner,
               repo,
               workflow_id: 'audit-weekly-evidence.yml',
               status: 'completed',
+              branch: 'main',
               per_page: 30,
             });
             const successRun = runs.data.workflow_runs.find((run) => run.conclusion === 'success');
             if (!successRun) {
-              core.setFailed('No successful Audit Weekly Evidence run found.');
+              core.setFailed(
+                'No successful Audit Weekly Evidence run found on main. ' +
+                'Run "Audit Weekly Evidence" first, then re-run this workflow.'
+              );
               return;
             }
             core.setOutput('run_id', String(successRun.id));
-            core.setOutput('run_url', successRun.html_url);
+            core.setOutput('run_url', successRun.html_url || '');
+            core.setOutput('skip_followup', 'false');
+            core.setOutput('source_trigger', 'workflow_dispatch');
 
       - name: Download weekly evidence artifact
+        if: steps.resolve.outputs.skip_followup != 'true'
         uses: actions/download-artifact@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,6 +108,7 @@ jobs:
           path: artifacts/audit-evidence
 
       - name: Upsert severe findings (dedupe by fingerprint)
+        if: steps.resolve.outputs.skip_followup != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -85,6 +120,7 @@ jobs:
             --skip-digest
 
       - name: Build weekly digest issue body
+        if: steps.resolve.outputs.skip_followup != 'true'
         run: |
           python3 - <<'PY'
           import json
@@ -137,6 +173,7 @@ jobs:
           PY
 
       - name: Create or update rolling digest issue
+        if: steps.resolve.outputs.skip_followup != 'true'
         id: digest
         uses: actions/github-script@v7
         with:
@@ -176,6 +213,7 @@ jobs:
             core.setOutput('issue_number', String(created.data.number));
 
       - name: Assign weekly digest to Copilot
+        if: steps.resolve.outputs.skip_followup != 'true'
         uses: actions/github-script@v7
         env:
           ISSUE_NUMBER: ${{ steps.digest.outputs.issue_number }}
@@ -214,3 +252,38 @@ jobs:
                 body: note,
               });
             }
+
+      - name: Weekly agent summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_trigger="${{ steps.resolve.outputs.source_trigger }}"
+          source_run_url="${{ steps.resolve.outputs.run_url }}"
+          skip_followup="${{ steps.resolve.outputs.skip_followup }}"
+          skip_reason="${{ steps.resolve.outputs.skip_reason }}"
+          digest_issue="${{ steps.digest.outputs.issue_number }}"
+          severe_count="n/a"
+          if [[ -f artifacts/audit-evidence/deterministic-findings.json ]]; then
+            severe_count="$(jq '[.[] | select(.severity == "s1" or .severity == "s2")] | length' artifacts/audit-evidence/deterministic-findings.json)"
+          fi
+
+          {
+            echo "## Weekly Agent Summary"
+            echo ""
+            echo "- Trigger event: \`${{ github.event_name }}\`"
+            echo "- Source resolution mode: \`${source_trigger:-unknown}\`"
+            if [[ -n "${source_run_url}" ]]; then
+              echo "- Source evidence run: ${source_run_url}"
+            fi
+            if [[ -z "${skip_followup}" && -z "${source_run_url}" ]]; then
+              echo "- Outcome: failed before source run resolution"
+            elif [[ "${skip_followup}" == "true" ]]; then
+              echo "- Outcome: skipped"
+              echo "- Reason: ${skip_reason:-source run was not successful}"
+            else
+              echo "- Outcome: processed"
+              echo "- Severe findings considered: \`${severe_count}\`"
+              echo "- Digest issue number: \`${digest_issue:-n/a}\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ Quick usage:
 1. Open PR and review `audit-evidence-pack` artifact from `Audit PR Evidence`.
 2. Add label `audit:deep` to request a Copilot deep audit issue for that PR.
 3. Review weekly digest issue for severe findings + rolling lower-severity notes.
+4. Manual run helpers:
+   - Weekly chain: run `Audit Weekly Evidence`, then run `Audit Weekly Agent` (or let `workflow_run` trigger it automatically).
+   - Deep agent: run `Audit PR Deep Agent` with `pr_number` (or leave blank to auto-detect when exactly one open PR targets `main`).
 
 Roadmap board:
 


### PR DESCRIPTION
## Summary
Stabilizes the GitHub audit agent workflows after post-merge manual run failures.

## Changes
- Add `workflow_run` chaining in `Audit Weekly Agent` from `Audit Weekly Evidence` completion.
- Make weekly evidence resolution resilient for both `workflow_run` and `workflow_dispatch`.
- Add weekly agent concurrency and clear step summary output.
- Make deep-agent `pr_number` optional for manual dispatch and auto-detect open PRs targeting `main`.
- Improve deep-agent failure messaging for invalid/ambiguous manual runs.
- Add deep-agent run summary output and README quick-run helper notes.

## Validation
- YAML parse check passed for both updated workflows.
- Manual `Audit Weekly Agent` rerun succeeded and created/upserted audit issues.
- Label-triggered deep-agent run on PR #207 succeeded and created deep-audit issue.
