### PR TITLE
Harden backup export helper with preflight checks and clearer usage

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -79,8 +79,7 @@ PYTHONPATH=$(pwd) mypy app
 - Full backup helper (Postgres dump + JSON + uploads):
 
   ```bash
-  cd ../infra/backup
-  DATABASE_URL=... ./export_all.sh
+  DATABASE_URL=... ./infra/backup/export_all.sh
   ```
 
 - Backup verification:

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -162,8 +162,7 @@ The simplest “all-in-one” backup is:
 Example (host-based), from repo root:
 
 ```bash
-cd infra/backup
-DATABASE_URL=postgresql://... ./export_all.sh
+DATABASE_URL=postgresql://... ./infra/backup/export_all.sh
 ```
 
 Recommended practice:

--- a/docs/README-legacy.md
+++ b/docs/README-legacy.md
@@ -69,8 +69,7 @@ You can swap pieces later, but the initial design assumes:
 - Full backup helper (Postgres dump + JSON + uploads):
 
   ```bash
-  cd infra/backup
-  ./export_all.sh  # requires DATABASE_URL env and pg_dump installed
+  DATABASE_URL=postgresql://... ./infra/backup/export_all.sh  # requires pg_dump
   ```
 
 - Verify a backup can restore:

--- a/infra/backup/export_all.sh
+++ b/infra/backup/export_all.sh
@@ -6,14 +6,54 @@ EXPORT_DIR="${BASE_DIR}/backups"
 MEDIA_DIR="${BASE_DIR}/uploads"
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
+usage() {
+  cat <<'EOF'
+Usage:
+  DATABASE_URL=postgresql://... ./infra/backup/export_all.sh
+
+Notes:
+  - Run from the repository root (as shown above), or from infra/backup with:
+      DATABASE_URL=postgresql://... ./export_all.sh
+  - Requires `pg_dump` to be installed and available on PATH.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "Error: DATABASE_URL is not set." >&2
+  echo "Set it inline when invoking the script, for example:" >&2
+  echo "  DATABASE_URL=postgresql://... ./infra/backup/export_all.sh" >&2
+  exit 1
+fi
+
+if ! command -v pg_dump >/dev/null 2>&1; then
+  echo "Error: pg_dump is not installed or not available in PATH." >&2
+  echo "Install PostgreSQL client tools, then re-run:" >&2
+  echo "  DATABASE_URL=postgresql://... ./infra/backup/export_all.sh" >&2
+  exit 1
+fi
+
 mkdir -p "$EXPORT_DIR"
 cd "$BASE_DIR"
 
 # Export JSON via app CLI
-python -m app.cli export-data --output "$EXPORT_DIR/export-${TIMESTAMP}.json"
+if ! PYTHONPATH=backend python -m app.cli export-data --output "$EXPORT_DIR/export-${TIMESTAMP}.json"; then
+  echo "Error: export command failed (python -m app.cli export-data)." >&2
+  echo "Check that backend Python dependencies are installed and your environment is configured." >&2
+  echo "Example: cd backend && pip install -r requirements.txt" >&2
+  exit 1
+fi
 
 # Postgres dump (requires PG* env vars)
-pg_dump "$DATABASE_URL" -Fc -f "$EXPORT_DIR/db-${TIMESTAMP}.dump"
+if ! pg_dump "$DATABASE_URL" -Fc -f "$EXPORT_DIR/db-${TIMESTAMP}.dump"; then
+  echo "Error: pg_dump failed for DATABASE_URL." >&2
+  echo "Verify DATABASE_URL points to a reachable Postgres instance and credentials are valid." >&2
+  exit 1
+fi
 
 # Archive everything
 tar -czf "$EXPORT_DIR/backup-${TIMESTAMP}.tar.gz" -C "$EXPORT_DIR" "export-${TIMESTAMP}.json" "db-${TIMESTAMP}.dump" -C "$BASE_DIR" "$(basename "$MEDIA_DIR")"


### PR DESCRIPTION
### Motivation
- Make the all-in-one backup helper more robust and actionable when run from the repo root or in CI. 
- Ensure the JSON export always finds the backend module and surface clear errors when prerequisites (DB URL, `pg_dump`) are missing or commands fail.

### Description
- Run the export CLI with `PYTHONPATH=backend` so `python -m app.cli export-data` works from the repository root. 
- Add `--help`/usage text explaining the recommended invocation: `DATABASE_URL=... ./infra/backup/export_all.sh`.
- Add preflight checks for `DATABASE_URL` and for `pg_dump` being available, and print actionable remediation guidance if missing. 
- Wrap the export and `pg_dump` steps in failure handlers that emit clear error messages and exit non-zero on failure. 
- Align documentation snippets in `docs/PRODUCTION.md`, `backend/README.md`, and `docs/README-legacy.md` to the repo-root invocation pattern (`./infra/backup/export_all.sh`).

### Testing
- Ran a shell syntax check with `bash -n infra/backup/export_all.sh`, which succeeded. 
- Ran `./infra/backup/export_all.sh --help` to verify usage text prints, which succeeded. 
- Executed the failure path with `env -u DATABASE_URL ./infra/backup/export_all.sh` to confirm the script exits with an actionable `DATABASE_URL` error, which behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a56724f88332adea4e9c22392f25)