### PR TITLE
feat(audit): complete phase 2 roadmap sync and docs

### DIFF
--- a/.github/workflows/audit-weekly-agent.yml
+++ b/.github/workflows/audit-weekly-agent.yml
@@ -109,6 +109,7 @@ jobs:
 
       - name: Upsert severe findings (dedupe by fingerprint)
         if: steps.resolve.outputs.skip_followup != 'true'
+        id: severe_upsert
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -117,7 +118,59 @@ jobs:
           python3 scripts/audit/upsert_audit_issues.py \
             --findings artifacts/audit-evidence/deterministic-findings.json \
             --run-url "$RUN_URL" \
+            --severe-output artifacts/audit-evidence/severe-issues-upserted.json \
             --skip-digest
+
+      - name: Sync severe issues to roadmap project
+        if: steps.resolve.outputs.skip_followup != 'true'
+        id: project_sync
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ROADMAP_PROJECT_WRITE_TOKEN: ${{ secrets.ROADMAP_PROJECT_WRITE_TOKEN }}
+          ROADMAP_PROJECT_OWNER: ${{ vars.ROADMAP_PROJECT_OWNER }}
+          ROADMAP_PROJECT_NUMBER: ${{ vars.ROADMAP_PROJECT_NUMBER }}
+        run: |
+          set -euo pipefail
+          severe_count="$(jq 'length' artifacts/audit-evidence/severe-issues-upserted.json)"
+          echo "severe_count=${severe_count}" >> "$GITHUB_OUTPUT"
+
+          if [[ "${severe_count}" == "0" ]]; then
+            python3 - <<'PY'
+            import json
+            from pathlib import Path
+
+            Path("artifacts/audit-evidence/project-sync-summary.json").write_text(
+                json.dumps(
+                    {
+                        "scanned": 0,
+                        "added": 0,
+                        "updated": 0,
+                        "lane_updates": 0,
+                        "status_updates": 0,
+                        "skipped_run": True,
+                        "skip_reason": "no_severe_issues",
+                        "project_owner": "Prekzursil",
+                        "project_number": 2,
+                        "project_url": "",
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            PY
+            exit 0
+          fi
+
+          python3 scripts/audit/sync_severe_issues_to_project.py \
+            --repo "${GITHUB_REPOSITORY}" \
+            --project-owner "${ROADMAP_PROJECT_OWNER:-Prekzursil}" \
+            --project-number "${ROADMAP_PROJECT_NUMBER:-2}" \
+            --issues-json artifacts/audit-evidence/severe-issues-upserted.json \
+            --lane-name "Now" \
+            --status-name "Todo" \
+            --summary-output artifacts/audit-evidence/project-sync-summary.json \
+            --allow-skip-missing-token
 
       - name: Build weekly digest issue body
         if: steps.resolve.outputs.skip_followup != 'true'
@@ -293,9 +346,21 @@ jobs:
           skip_followup="${{ steps.resolve.outputs.skip_followup }}"
           skip_reason="${{ steps.resolve.outputs.skip_reason }}"
           digest_issue="${{ steps.digest.outputs.issue_number }}"
-          severe_count="n/a"
-          if [[ -f artifacts/audit-evidence/deterministic-findings.json ]]; then
-            severe_count="$(jq '[.[] | select(.severity == "s1" or .severity == "s2")] | length' artifacts/audit-evidence/deterministic-findings.json)"
+          severe_count="${{ steps.project_sync.outputs.severe_count }}"
+          project_sync_added="n/a"
+          project_sync_updated="n/a"
+          project_sync_lane_updates="n/a"
+          project_sync_status_updates="n/a"
+          project_sync_skip_reason="n/a"
+          project_sync_url="n/a"
+
+          if [[ -f artifacts/audit-evidence/project-sync-summary.json ]]; then
+            project_sync_added="$(jq '.added // 0' artifacts/audit-evidence/project-sync-summary.json)"
+            project_sync_updated="$(jq '.updated // 0' artifacts/audit-evidence/project-sync-summary.json)"
+            project_sync_lane_updates="$(jq '.lane_updates // 0' artifacts/audit-evidence/project-sync-summary.json)"
+            project_sync_status_updates="$(jq '.status_updates // 0' artifacts/audit-evidence/project-sync-summary.json)"
+            project_sync_skip_reason="$(jq -r '.skip_reason // \"none\"' artifacts/audit-evidence/project-sync-summary.json)"
+            project_sync_url="$(jq -r '.project_url // \"\"' artifacts/audit-evidence/project-sync-summary.json)"
           fi
 
           {
@@ -313,7 +378,15 @@ jobs:
               echo "- Reason: ${skip_reason:-source run was not successful}"
             else
               echo "- Outcome: processed"
-              echo "- Severe findings considered: \`${severe_count}\`"
+              echo "- Severe findings considered: \`${severe_count:-n/a}\`"
               echo "- Digest issue number: \`${digest_issue:-n/a}\`"
+              echo "- Project sync added: \`${project_sync_added}\`"
+              echo "- Project sync updated: \`${project_sync_updated}\`"
+              echo "- Project lane updates: \`${project_sync_lane_updates}\`"
+              echo "- Project status updates: \`${project_sync_status_updates}\`"
+              echo "- Project sync skip reason: \`${project_sync_skip_reason}\`"
+              if [[ -n "${project_sync_url}" && "${project_sync_url}" != "n/a" ]]; then
+                echo "- Target roadmap project: ${project_sync_url}"
+              fi
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,20 @@ This repo uses an evidence-first AI pipeline:
 
 CI only collects deterministic evidence. Agent judgments happen through Copilot issue assignment (`@copilot`).
 
+### Maintainer weekly triage flow
+
+For the weekly cycle:
+
+1. Ensure `Audit Weekly Evidence` succeeds.
+2. Run/confirm `Audit Weekly Agent`.
+3. Verify severe findings (`severity:s1/s2`) were upserted.
+4. If `ROADMAP_PROJECT_WRITE_TOKEN` is configured:
+   - severe audit issues should be synced to `AdrianaArt Roadmap` lane `Now`.
+5. If token is not configured:
+   - workflow remains green and reports an explicit skip reason in the summary.
+
+The weekly project sync is additive-only in this phase: it does not auto-remove or archive project items when issues later close.
+
 ## Required checks for `main`
 
 Branch protection should enforce the checks defined in `docs/REPOSITORY_POLICY.md`:

--- a/TODO.md
+++ b/TODO.md
@@ -110,7 +110,9 @@ showing what is already implemented.
   - Evidence: `scripts/audit/normalize_findings_fingerprint.py`, `scripts/audit/upsert_audit_issues.py`, `scripts/audit/collect_audit_evidence.py`
 - [x] Copilot governance: add repo-level + path-scoped Copilot instructions and AI governance apply helper.
   - Evidence: `.github/copilot-instructions.md`, `.github/instructions/storefront.instructions.md`, `.github/instructions/account.instructions.md`, `.github/instructions/admin.instructions.md`, `.github/instructions/backend-api.instructions.md`, `scripts/repo/apply_ai_governance.sh`
-- [ ] AI audit phase 2: auto-sync severe audit issues to roadmap project lane `Now` when project-write token is configured.
+- [x] AI audit phase 2: auto-sync severe audit issues to roadmap project lane `Now` when project-write token is configured.
+  - Evidence: `.github/workflows/audit-weekly-agent.yml`, `scripts/audit/upsert_audit_issues.py`, `scripts/audit/sync_severe_issues_to_project.py`, `docs/AI_AUDIT_PHASES.md`
+- [ ] AI audit phase 3: bi-directional roadmap sync (auto-update lane/status based on issue lifecycle + closure policy).
 - [x] Repo policy phase 2: evaluate enabling required review approvals once contributor cadence grows.
   - Evidence: `docs/REPOSITORY_POLICY.md`, `docs/reports/repo-policy-phase2-baseline-2026-02.md`, `docs/reports/repo-policy-phase2-baseline-2026-02.json`
 - [x] DAM (local-only): add first-party media domain models + local-volume storage layout + Redis job queue primitives (no S3/cloud adapters).

--- a/docs/AI_AUDIT_PHASES.md
+++ b/docs/AI_AUDIT_PHASES.md
@@ -1,0 +1,170 @@
+# AI Audit Phases
+
+This document defines the two implemented phases of the repository AI audit program.
+
+## Goal
+
+Keep audit automation deterministic, reproducible, and low-noise while still benefiting from agent-driven analysis and triage.
+
+The split is explicit:
+
+1. Evidence Pack (deterministic CI) collects facts.
+2. Agent Pass (Copilot issue assignment) produces judgment.
+
+No OpenAI/Anthropic API calls are used in CI workflows for this program.
+
+## Phase 1 (Implemented): Evidence Pack + Agent Pass
+
+### Architecture
+
+Phase 1 is intentionally split into deterministic collection and agent reasoning.
+
+Deterministic artifacts are produced by:
+
+- `scripts/audit/collect_audit_evidence.py`
+- `scripts/audit/extract_route_map.py`
+- `scripts/audit/normalize_findings_fingerprint.py`
+
+Primary workflows:
+
+- `.github/workflows/audit-pr-evidence.yml`
+- `.github/workflows/audit-weekly-evidence.yml`
+- `.github/workflows/audit-weekly-agent.yml`
+- `.github/workflows/audit-pr-deep-agent.yml`
+- `.github/workflows/audit-agent-watchdog.yml`
+
+Output artifact contract (`audit-evidence-pack`):
+
+- `route-map.json`
+- `surface-map.json`
+- `seo-snapshot.json`
+- `console-errors.json`
+- `layout-signals.json`
+- `deterministic-findings.json`
+- `screenshots/`
+- `evidence-index.md`
+
+### Trigger model
+
+- PR path:
+  - `Audit PR Evidence` runs on pull requests to `main`.
+  - `Audit PR Deep Agent` is opt-in and label-gated (`audit:deep`).
+- Weekly path:
+  - `Audit Weekly Evidence` runs on schedule/manual.
+  - `Audit Weekly Agent` runs from weekly evidence completion and can be manually dispatched.
+
+### Issue lifecycle
+
+- Severe findings (`severity:s1`, `severity:s2`): upserted as individual issues, deduped by deterministic fingerprint.
+- Lower findings (`severity:s3`, `severity:s4`): aggregated in `Weekly UX/IA Audit Digest`.
+- Agent labels:
+  - `ai:ready`
+  - `ai:in-progress`
+  - `ai:done`
+  - `ai:blocked`
+
+### Watchdog behavior
+
+`audit-agent-watchdog.yml` de-stalls stale in-progress issues:
+
+- Scans open `ai:in-progress` issues.
+- On stale threshold, comments, re-queues (`ai:ready`), and unassigns `copilot`.
+
+## Phase 1 runbook
+
+### Weekly expected flow
+
+1. `Audit Weekly Evidence` succeeds and uploads `audit-evidence-pack`.
+2. `Audit Weekly Agent` consumes that run.
+3. Severe issues are upserted.
+4. Weekly digest issue is created/updated and assigned to `@copilot`.
+
+### Common failure modes
+
+- No successful weekly evidence run:
+  - Weekly agent fails source resolution when no successful evidence run exists.
+- Copilot assignment unavailable:
+  - Workflow leaves fallback guidance comment and keeps issue open.
+- Artifact mismatch:
+  - If findings file is missing/invalid, severe upsert cannot proceed.
+
+## Phase 2 (Implemented): Severe issue roadmap auto-sync
+
+Phase 2 adds an optional project sync so open severe issues are mirrored into the roadmap lane `Now`.
+
+### Scope
+
+- Sync target: user project `Prekzursil` #2 by default (`AdrianaArt Roadmap`).
+- Source: severe issue upsert output from weekly agent run.
+- Policy:
+  - Upsert open severe issues into project.
+  - Force `Roadmap Lane=Now`.
+  - Set `Status=Todo` only when status is empty or non-terminal.
+  - Do not auto-remove/archive items in this phase.
+
+### Token-gated execution
+
+Phase 2 runs only when a project write token is configured.
+
+Configuration:
+
+- Secret: `ROADMAP_PROJECT_WRITE_TOKEN` (optional)
+- Variable: `ROADMAP_PROJECT_OWNER` (default `Prekzursil`)
+- Variable: `ROADMAP_PROJECT_NUMBER` (default `2`)
+
+If `ROADMAP_PROJECT_WRITE_TOKEN` is missing:
+
+- Workflow stays green.
+- Sync step is skipped with explicit reason in step summary.
+
+### Implementation components
+
+- Severe handoff output:
+  - `scripts/audit/upsert_audit_issues.py` via `--severe-output`
+- Project sync engine:
+  - `scripts/audit/sync_severe_issues_to_project.py`
+- Weekly wiring:
+  - `.github/workflows/audit-weekly-agent.yml`
+
+### Data handoff contract
+
+`severe-issues-upserted.json` rows include:
+
+- `issue_number`
+- `issue_node_id`
+- `fingerprint`
+- `route`
+- `surface`
+- `severity`
+- `action` (`created` or `updated`)
+
+`project-sync-summary.json` includes:
+
+- `scanned`
+- `added`
+- `updated`
+- `lane_updates`
+- `status_updates`
+- `skip_reason` (when skipped)
+- `project_url`
+
+## Security and operational constraints
+
+- Project sync uses strict GraphQL variables (no query string interpolation).
+- Tokens are never printed in logs.
+- Repo/path inputs are validated and path writes stay in audit artifact roots.
+- Phase 2 only mutates project metadata; it does not change code/runtime behavior.
+
+## Validation checklist
+
+1. Run weekly evidence.
+2. Run weekly agent with token missing and verify safe skip summary.
+3. Configure `ROADMAP_PROJECT_WRITE_TOKEN` and rerun weekly agent.
+4. Verify severe issues appear in `AdrianaArt Roadmap` lane `Now`.
+5. Verify no duplicate project items for rerun of same severe issues.
+
+## Next phase
+
+Planned follow-up:
+
+- AI audit phase 3: bi-directional roadmap sync based on issue lifecycle and closure policy.

--- a/docs/REPOSITORY_POLICY.md
+++ b/docs/REPOSITORY_POLICY.md
@@ -120,6 +120,52 @@ Security constraints:
   - requires `audit:deep` label.
   - produces/updates one deep-audit issue for that PR.
 
+## AI Audit Phase 2: Roadmap Auto-Sync
+
+Phase 2 extends the weekly agent flow with optional project synchronization:
+
+- Source: severe issue upsert output from `scripts/audit/upsert_audit_issues.py` (`--severe-output`).
+- Target: `AdrianaArt Roadmap` (`Prekzursil` project `#2` by default, overridable via variables).
+- Behavior:
+  - upsert open severe issues into project items.
+  - enforce `Roadmap Lane=Now`.
+  - set `Status=Todo` only when status is empty or non-terminal.
+  - do not auto-remove/archive items in this phase.
+
+Configuration:
+
+- Secret: `ROADMAP_PROJECT_WRITE_TOKEN` (optional)
+- Variable: `ROADMAP_PROJECT_OWNER` (optional, default `Prekzursil`)
+- Variable: `ROADMAP_PROJECT_NUMBER` (optional, default `2`)
+
+Safety rules:
+
+- If project write token is missing, the sync step is skipped safely and workflow stays green.
+- Skip reason is emitted in weekly workflow summary.
+- No token value is printed in logs.
+
+## Sentry Observability Baseline
+
+Sentry remains opt-in and environment-driven:
+
+- Backend captures errors/traces/profiles with additive config keys:
+  - `SENTRY_DSN`
+  - `SENTRY_TRACES_SAMPLE_RATE`
+  - `SENTRY_PROFILES_SAMPLE_RATE`
+  - `SENTRY_ENABLE_LOGS`
+  - `SENTRY_LOG_LEVEL`
+- Frontend captures errors/traces/replays through runtime config:
+  - `SENTRY_DSN`
+  - `SENTRY_TRACES_SAMPLE_RATE`
+  - `SENTRY_REPLAY_SESSION_SAMPLE_RATE`
+  - `SENTRY_REPLAY_ON_ERROR_SAMPLE_RATE`
+
+Operational guardrails:
+
+- Never hardcode DSNs in source-controlled files.
+- Keep sampling rates environment-specific.
+- If noise/cost spikes, set rates to `0` as first-line rollback.
+
 
 ## Agent Issue Watchdog
 

--- a/scripts/audit/sync_severe_issues_to_project.py
+++ b/scripts/audit/sync_severe_issues_to_project.py
@@ -1,0 +1,690 @@
+#!/usr/bin/env python3
+"""Sync severe audit issues into a GitHub ProjectV2 roadmap lane."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+TERMINAL_STATUS_NAMES = {"done", "closed", "completed"}
+GRAPHQL_URL = "https://api.github.com/graphql"
+
+
+@dataclass(frozen=True)
+class RepoRef:
+    owner: str
+    repo: str
+
+
+@dataclass(frozen=True)
+class ProjectRef:
+    project_id: str
+    project_url: str
+    lane_field_id: str
+    lane_option_id: str
+    status_field_id: str
+    status_option_id: str
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _resolve_repo_path(raw: str, *, allowed_prefixes: tuple[str, ...]) -> Path:
+    root = _repo_root()
+    candidate = (root / raw).resolve()
+    try:
+        rel = candidate.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise ValueError(f"Path must stay inside repository: {raw}") from exc
+    if not any(rel == prefix or rel.startswith(f"{prefix}/") for prefix in allowed_prefixes):
+        raise ValueError(f"Path is outside allowed audit roots: {raw}")
+    return candidate
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _validate_identifier(value: str, *, label: str) -> str:
+    raw = value.strip()
+    if not raw:
+        raise ValueError(f"Missing {label}.")
+    if not IDENTIFIER_RE.fullmatch(raw):
+        raise ValueError(f"Invalid {label}: {raw}")
+    return raw
+
+
+def _parse_repo(full_name: str) -> RepoRef:
+    if "/" not in full_name:
+        raise ValueError("Repository must be owner/repo format.")
+    owner_raw, repo_raw = full_name.split("/", 1)
+    owner = _validate_identifier(owner_raw, label="repository owner")
+    repo = _validate_identifier(repo_raw, label="repository name")
+    return RepoRef(owner=owner, repo=repo)
+
+
+def _graphql_request(token: str, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    payload = json.dumps({"query": query, "variables": variables}).encode("utf-8")
+    req = urllib.request.Request(
+        url=GRAPHQL_URL,
+        method="POST",
+        data=payload,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "adrianaart-audit-project-sync",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = resp.read().decode("utf-8")
+            payload_json = json.loads(body) if body else {}
+    except urllib.error.HTTPError as exc:
+        _ = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub GraphQL request failed: HTTP {exc.code}.") from exc
+
+    errors = payload_json.get("errors") or []
+    if errors:
+        first = errors[0] if isinstance(errors[0], dict) else {"message": str(errors[0])}
+        message = str(first.get("message") or "GraphQL request failed.")
+        raise RuntimeError(f"GitHub GraphQL request failed: {message}")
+    data = payload_json.get("data")
+    if not isinstance(data, dict):
+        raise RuntimeError("GitHub GraphQL request failed: missing data payload.")
+    return data
+
+
+def _resolve_project(
+    *,
+    token: str,
+    project_owner: str,
+    project_number: int,
+    lane_name: str,
+    status_name: str,
+    request_fn: Callable[[str, str, dict[str, Any]], dict[str, Any]],
+) -> ProjectRef:
+    query = """
+    query ResolveProject($owner: String!, $number: Int!) {
+      user(login: $owner) {
+        projectV2(number: $number) {
+          id
+          url
+          closed
+          fields(first: 100) {
+            nodes {
+              __typename
+              ... on ProjectV2FieldCommon {
+                id
+                name
+              }
+              ... on ProjectV2SingleSelectField {
+                id
+                name
+                options {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+      organization(login: $owner) {
+        projectV2(number: $number) {
+          id
+          url
+          closed
+          fields(first: 100) {
+            nodes {
+              __typename
+              ... on ProjectV2FieldCommon {
+                id
+                name
+              }
+              ... on ProjectV2SingleSelectField {
+                id
+                name
+                options {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    data = request_fn(token, query, {"owner": project_owner, "number": project_number})
+
+    project = None
+    user_node = data.get("user") if isinstance(data.get("user"), dict) else None
+    org_node = data.get("organization") if isinstance(data.get("organization"), dict) else None
+    if user_node and isinstance(user_node.get("projectV2"), dict):
+        project = user_node["projectV2"]
+    elif org_node and isinstance(org_node.get("projectV2"), dict):
+        project = org_node["projectV2"]
+
+    if not isinstance(project, dict):
+        raise RuntimeError(f"Project not found for {project_owner} #{project_number}.")
+    if bool(project.get("closed")):
+        raise RuntimeError(f"Project {project_owner} #{project_number} is closed.")
+
+    fields_nodes = (
+        ((project.get("fields") or {}).get("nodes"))
+        if isinstance(project.get("fields"), dict)
+        else []
+    )
+    fields_nodes = fields_nodes if isinstance(fields_nodes, list) else []
+
+    lane_field_id = ""
+    lane_option_id = ""
+    status_field_id = ""
+    status_option_id = ""
+
+    for field in fields_nodes:
+        if not isinstance(field, dict):
+            continue
+        name = str(field.get("name") or "")
+        if name == "Roadmap Lane":
+            lane_field_id = str(field.get("id") or "")
+            options = field.get("options") if isinstance(field.get("options"), list) else []
+            for option in options:
+                if isinstance(option, dict) and str(option.get("name") or "") == lane_name:
+                    lane_option_id = str(option.get("id") or "")
+        if name == "Status":
+            status_field_id = str(field.get("id") or "")
+            options = field.get("options") if isinstance(field.get("options"), list) else []
+            for option in options:
+                if isinstance(option, dict) and str(option.get("name") or "") == status_name:
+                    status_option_id = str(option.get("id") or "")
+
+    if not lane_field_id:
+        raise RuntimeError("Project field 'Roadmap Lane' not found.")
+    if not lane_option_id:
+        raise RuntimeError(f"Roadmap Lane option '{lane_name}' not found.")
+    if not status_field_id:
+        raise RuntimeError("Project field 'Status' not found.")
+    if not status_option_id:
+        raise RuntimeError(f"Status option '{status_name}' not found.")
+
+    return ProjectRef(
+        project_id=str(project.get("id") or ""),
+        project_url=str(project.get("url") or ""),
+        lane_field_id=lane_field_id,
+        lane_option_id=lane_option_id,
+        status_field_id=status_field_id,
+        status_option_id=status_option_id,
+    )
+
+
+def _list_project_issue_items(
+    *,
+    token: str,
+    project_id: str,
+    request_fn: Callable[[str, str, dict[str, Any]], dict[str, Any]],
+) -> dict[str, dict[str, str]]:
+    query = """
+    query ProjectItems($projectId: ID!, $after: String) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          items(first: 100, after: $after) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              id
+              content {
+                __typename
+                ... on Issue {
+                  id
+                  number
+                }
+              }
+              fieldValues(first: 30) {
+                nodes {
+                  __typename
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                    optionId
+                    field {
+                      ... on ProjectV2FieldCommon {
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    after: str | None = None
+    mapping: dict[str, dict[str, str]] = {}
+
+    while True:
+        payload = request_fn(token, query, {"projectId": project_id, "after": after})
+        node = payload.get("node") if isinstance(payload.get("node"), dict) else None
+        if not node:
+            break
+        items = node.get("items") if isinstance(node.get("items"), dict) else {}
+        nodes = items.get("nodes") if isinstance(items.get("nodes"), list) else []
+
+        for item in nodes:
+            if not isinstance(item, dict):
+                continue
+            content = item.get("content") if isinstance(item.get("content"), dict) else None
+            if not content or str(content.get("__typename") or "") != "Issue":
+                continue
+            issue_node_id = str(content.get("id") or "")
+            if not issue_node_id:
+                continue
+            status_name = ""
+            lane_name = ""
+            field_values = item.get("fieldValues") if isinstance(item.get("fieldValues"), dict) else {}
+            values_nodes = field_values.get("nodes") if isinstance(field_values.get("nodes"), list) else []
+            for value in values_nodes:
+                if not isinstance(value, dict):
+                    continue
+                if str(value.get("__typename") or "") != "ProjectV2ItemFieldSingleSelectValue":
+                    continue
+                field = value.get("field") if isinstance(value.get("field"), dict) else {}
+                field_name = str(field.get("name") or "")
+                selected_name = str(value.get("name") or "")
+                if field_name == "Status":
+                    status_name = selected_name
+                elif field_name == "Roadmap Lane":
+                    lane_name = selected_name
+            mapping[issue_node_id] = {
+                "item_id": str(item.get("id") or ""),
+                "status_name": status_name,
+                "lane_name": lane_name,
+            }
+
+        page_info = items.get("pageInfo") if isinstance(items.get("pageInfo"), dict) else {}
+        has_next = bool(page_info.get("hasNextPage"))
+        if not has_next:
+            break
+        after = str(page_info.get("endCursor") or "")
+        if not after:
+            break
+
+    return mapping
+
+
+def _resolve_issue_node_id(
+    *,
+    token: str,
+    repo: RepoRef,
+    issue_number: int,
+    request_fn: Callable[[str, str, dict[str, Any]], dict[str, Any]],
+) -> str:
+    query = """
+    query IssueNodeId($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) {
+          id
+          number
+        }
+      }
+    }
+    """
+    data = request_fn(
+        token,
+        query,
+        {"owner": repo.owner, "repo": repo.repo, "number": issue_number},
+    )
+    repository = data.get("repository") if isinstance(data.get("repository"), dict) else None
+    if not repository:
+        return ""
+    issue = repository.get("issue") if isinstance(repository.get("issue"), dict) else None
+    if not issue:
+        return ""
+    return str(issue.get("id") or "")
+
+
+def _add_project_item(
+    *,
+    token: str,
+    project_id: str,
+    issue_node_id: str,
+    request_fn: Callable[[str, str, dict[str, Any]], dict[str, Any]],
+) -> str:
+    mutation = """
+    mutation AddProjectItem($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+        item {
+          id
+        }
+      }
+    }
+    """
+    data = request_fn(token, mutation, {"projectId": project_id, "contentId": issue_node_id})
+    item = (
+        (((data.get("addProjectV2ItemById") or {}).get("item"))
+         if isinstance(data.get("addProjectV2ItemById"), dict)
+         else None)
+        or {}
+    )
+    item_id = str(item.get("id") or "")
+    if not item_id:
+        raise RuntimeError("Failed to add project item: missing item id.")
+    return item_id
+
+
+def _set_single_select_field(
+    *,
+    token: str,
+    project_id: str,
+    item_id: str,
+    field_id: str,
+    option_id: str,
+    request_fn: Callable[[str, str, dict[str, Any]], dict[str, Any]],
+) -> None:
+    mutation = """
+    mutation SetSingleSelect($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+      updateProjectV2ItemFieldValue(
+        input: {
+          projectId: $projectId
+          itemId: $itemId
+          fieldId: $fieldId
+          value: { singleSelectOptionId: $optionId }
+        }
+      ) {
+        projectV2Item {
+          id
+        }
+      }
+    }
+    """
+    request_fn(
+        token,
+        mutation,
+        {
+            "projectId": project_id,
+            "itemId": item_id,
+            "fieldId": field_id,
+            "optionId": option_id,
+        },
+    )
+
+
+def _load_severe_issues(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("issues-json must contain a JSON array.")
+
+    deduped: dict[int, dict[str, Any]] = {}
+    for row in payload:
+        if not isinstance(row, dict):
+            continue
+        issue_number_raw = row.get("issue_number")
+        if isinstance(issue_number_raw, bool):
+            continue
+        try:
+            issue_number = int(issue_number_raw)
+        except (TypeError, ValueError):
+            continue
+        if issue_number <= 0:
+            continue
+        deduped[issue_number] = {
+            "issue_number": issue_number,
+            "issue_node_id": str(row.get("issue_node_id") or "").strip(),
+            "fingerprint": str(row.get("fingerprint") or "").strip(),
+            "severity": str(row.get("severity") or "").strip().lower(),
+            "route": str(row.get("route") or "").strip(),
+            "surface": str(row.get("surface") or "").strip(),
+            "action": str(row.get("action") or "").strip(),
+        }
+
+    return list(deduped.values())
+
+
+def _should_set_status_todo(current_status: str, target_status: str) -> bool:
+    status = current_status.strip()
+    if not status:
+        return True
+    if status.lower() in TERMINAL_STATUS_NAMES:
+        return False
+    return status != target_status
+
+
+def run_sync(
+    *,
+    token: str,
+    repo: RepoRef,
+    project_owner: str,
+    project_number: int,
+    issues_path: Path,
+    lane_name: str,
+    status_name: str,
+    dry_run: bool,
+    allow_skip_missing_token: bool,
+    request_fn: Callable[[str, str, dict[str, Any]], dict[str, Any]],
+) -> dict[str, Any]:
+    issues = _load_severe_issues(issues_path)
+    summary: dict[str, Any] = {
+        "repo": f"{repo.owner}/{repo.repo}",
+        "project_owner": project_owner,
+        "project_number": project_number,
+        "project_url": "",
+        "lane_name": lane_name,
+        "status_name": status_name,
+        "scanned": len(issues),
+        "added": 0,
+        "updated": 0,
+        "lane_updates": 0,
+        "status_updates": 0,
+        "skipped": 0,
+        "errors": 0,
+        "results": [],
+    }
+
+    if not token:
+        if allow_skip_missing_token:
+            summary.update({"skipped": len(issues), "skip_reason": "missing_project_write_token", "skipped_run": True})
+            return summary
+        raise RuntimeError("Missing ROADMAP_PROJECT_WRITE_TOKEN.")
+
+    if not issues:
+        summary.update({"skip_reason": "no_severe_issues", "skipped_run": True})
+        return summary
+
+    project = _resolve_project(
+        token=token,
+        project_owner=project_owner,
+        project_number=project_number,
+        lane_name=lane_name,
+        status_name=status_name,
+        request_fn=request_fn,
+    )
+    summary["project_url"] = project.project_url
+
+    existing_items = _list_project_issue_items(token=token, project_id=project.project_id, request_fn=request_fn)
+
+    for issue in issues:
+        issue_number = int(issue["issue_number"])
+        issue_node_id = str(issue.get("issue_node_id") or "")
+        if not issue_node_id:
+            issue_node_id = _resolve_issue_node_id(
+                token=token,
+                repo=repo,
+                issue_number=issue_number,
+                request_fn=request_fn,
+            )
+        if not issue_node_id:
+            summary["errors"] += 1
+            summary["results"].append(
+                {
+                    "issue_number": issue_number,
+                    "result": "error",
+                    "error": "issue_node_id_not_found",
+                }
+            )
+            continue
+
+        existing = existing_items.get(issue_node_id)
+        item_id = ""
+        was_added = False
+        status_current = ""
+        lane_current = ""
+
+        if existing:
+            item_id = str(existing.get("item_id") or "")
+            lane_current = str(existing.get("lane_name") or "")
+            status_current = str(existing.get("status_name") or "")
+            summary["updated"] += 1
+        else:
+            was_added = True
+            summary["added"] += 1
+            if not dry_run:
+                item_id = _add_project_item(
+                    token=token,
+                    project_id=project.project_id,
+                    issue_node_id=issue_node_id,
+                    request_fn=request_fn,
+                )
+            else:
+                item_id = f"dry-run-{issue_number}"
+
+        lane_changed = lane_current != lane_name
+        if lane_changed:
+            summary["lane_updates"] += 1
+            if not dry_run:
+                _set_single_select_field(
+                    token=token,
+                    project_id=project.project_id,
+                    item_id=item_id,
+                    field_id=project.lane_field_id,
+                    option_id=project.lane_option_id,
+                    request_fn=request_fn,
+                )
+
+        status_changed = _should_set_status_todo(status_current, status_name)
+        if status_changed:
+            summary["status_updates"] += 1
+            if not dry_run:
+                _set_single_select_field(
+                    token=token,
+                    project_id=project.project_id,
+                    item_id=item_id,
+                    field_id=project.status_field_id,
+                    option_id=project.status_option_id,
+                    request_fn=request_fn,
+                )
+
+        summary["results"].append(
+            {
+                "issue_number": issue_number,
+                "issue_node_id": issue_node_id,
+                "result": "added" if was_added else "updated",
+                "lane_changed": lane_changed,
+                "status_changed": status_changed,
+            }
+        )
+
+    if summary["errors"] > 0:
+        raise RuntimeError(
+            "Project sync completed with errors "
+            f"(errors={summary['errors']}, added={summary['added']}, updated={summary['updated']})."
+        )
+
+    return summary
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="Repository in owner/repo format.")
+    parser.add_argument("--project-owner", default="Prekzursil", help="Project owner login.")
+    parser.add_argument("--project-number", type=int, default=2, help="ProjectV2 number.")
+    parser.add_argument("--issues-json", required=True, help="Path to severe issues handoff JSON.")
+    parser.add_argument("--lane-name", default="Now", help="Roadmap Lane option name.")
+    parser.add_argument("--status-name", default="Todo", help="Status option name.")
+    parser.add_argument("--summary-output", default="", help="Optional output path for summary JSON.")
+    parser.add_argument("--dry-run", action="store_true", help="Do not mutate project items.")
+    parser.add_argument(
+        "--allow-skip-missing-token",
+        action="store_true",
+        help="Exit 0 with a skipped summary when ROADMAP_PROJECT_WRITE_TOKEN is missing.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+
+    repo = _parse_repo(args.repo)
+    project_owner = _validate_identifier(args.project_owner, label="project owner")
+    project_number = int(args.project_number)
+    if project_number <= 0:
+        raise ValueError("project-number must be a positive integer.")
+
+    issues_path = _resolve_repo_path(
+        args.issues_json,
+        allowed_prefixes=("artifacts/audit-evidence", "artifacts/audit-evidence-local"),
+    )
+    if not issues_path.exists():
+        raise FileNotFoundError(f"Issues JSON not found: {issues_path}")
+
+    summary_path = None
+    if args.summary_output:
+        summary_path = _resolve_repo_path(
+            args.summary_output,
+            allowed_prefixes=("artifacts/audit-evidence", "artifacts/audit-evidence-local"),
+        )
+
+    token = (os.environ.get("ROADMAP_PROJECT_WRITE_TOKEN") or "").strip()
+
+    summary = run_sync(
+        token=token,
+        repo=repo,
+        project_owner=project_owner,
+        project_number=project_number,
+        issues_path=issues_path,
+        lane_name=str(args.lane_name).strip() or "Now",
+        status_name=str(args.status_name).strip() or "Todo",
+        dry_run=bool(args.dry_run),
+        allow_skip_missing_token=bool(args.allow_skip_missing_token),
+        request_fn=_graphql_request,
+    )
+
+    if summary_path is not None:
+        _write_json(summary_path, summary)
+
+    print(
+        "Project sync summary: "
+        f"scanned={summary.get('scanned', 0)} "
+        f"added={summary.get('added', 0)} "
+        f"updated={summary.get('updated', 0)} "
+        f"lane_updates={summary.get('lane_updates', 0)} "
+        f"status_updates={summary.get('status_updates', 0)} "
+        f"skipped_reason={summary.get('skip_reason', '') or 'none'}"
+    )
+    if summary.get("project_url"):
+        print(f"Target project: {summary['project_url']}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # pragma: no cover - defensive CLI guard
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/audit/tests/test_sync_severe_issues_to_project.py
+++ b/scripts/audit/tests/test_sync_severe_issues_to_project.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[1] / "sync_severe_issues_to_project.py"
+    spec = importlib.util.spec_from_file_location("sync_severe_issues_to_project", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_issues(path: Path, payload: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _project_payload(*, include_lane: bool = True):
+    fields = [
+        {
+            "__typename": "ProjectV2SingleSelectField",
+            "id": "F_STATUS",
+            "name": "Status",
+            "options": [
+                {"id": "OPT_TODO", "name": "Todo"},
+                {"id": "OPT_DONE", "name": "Done"},
+            ],
+        }
+    ]
+    if include_lane:
+        fields.append(
+            {
+                "__typename": "ProjectV2SingleSelectField",
+                "id": "F_LANE",
+                "name": "Roadmap Lane",
+                "options": [
+                    {"id": "OPT_NOW", "name": "Now"},
+                    {"id": "OPT_NEXT", "name": "Next"},
+                ],
+            }
+        )
+    return {
+        "user": {
+            "projectV2": {
+                "id": "PVT_1",
+                "url": "https://github.com/users/Prekzursil/projects/2",
+                "closed": False,
+                "fields": {"nodes": fields},
+            }
+        },
+        "organization": None,
+    }
+
+
+def test_run_sync_missing_token_safe_skip(tmp_path) -> None:
+    module = _load_module()
+    issues_path = tmp_path / "artifacts" / "audit-evidence" / "severe.json"
+    _write_issues(issues_path, [{"issue_number": 1, "issue_node_id": "I_1"}])
+
+    summary = module.run_sync(
+        token="",
+        repo=module.RepoRef(owner="Prekzursil", repo="AdrianaArt"),
+        project_owner="Prekzursil",
+        project_number=2,
+        issues_path=issues_path,
+        lane_name="Now",
+        status_name="Todo",
+        dry_run=False,
+        allow_skip_missing_token=True,
+        request_fn=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected call")),
+    )
+
+    assert summary["skipped_run"] is True
+    assert summary["skip_reason"] == "missing_project_write_token"
+    assert summary["skipped"] == 1
+
+
+def test_run_sync_adds_missing_issue_and_sets_lane_and_status(tmp_path) -> None:
+    module = _load_module()
+    issues_path = tmp_path / "artifacts" / "audit-evidence" / "severe.json"
+    _write_issues(issues_path, [{"issue_number": 220, "issue_node_id": "ISSUE_220"}])
+
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_request(_token: str, query: str, variables: dict[str, object]) -> dict[str, object]:
+        if "query ResolveProject" in query:
+            return _project_payload()
+        if "query ProjectItems" in query:
+            return {
+                "node": {
+                    "items": {
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+        if "mutation AddProjectItem" in query:
+            calls.append(("add", variables))
+            return {"addProjectV2ItemById": {"item": {"id": "ITEM_220"}}}
+        if "mutation SetSingleSelect" in query:
+            calls.append(("set", variables))
+            return {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_220"}}}
+        raise AssertionError(f"Unexpected query: {query[:80]}")
+
+    summary = module.run_sync(
+        token="token",
+        repo=module.RepoRef(owner="Prekzursil", repo="AdrianaArt"),
+        project_owner="Prekzursil",
+        project_number=2,
+        issues_path=issues_path,
+        lane_name="Now",
+        status_name="Todo",
+        dry_run=False,
+        allow_skip_missing_token=False,
+        request_fn=fake_request,
+    )
+
+    assert summary["added"] == 1
+    assert summary["updated"] == 0
+    assert summary["lane_updates"] == 1
+    assert summary["status_updates"] == 1
+    assert summary["results"][0]["result"] == "added"
+    assert [name for name, _ in calls].count("add") == 1
+    assert [name for name, _ in calls].count("set") == 2
+
+
+def test_run_sync_updates_existing_and_preserves_done_status(tmp_path) -> None:
+    module = _load_module()
+    issues_path = tmp_path / "artifacts" / "audit-evidence" / "severe.json"
+    _write_issues(issues_path, [{"issue_number": 221, "issue_node_id": "ISSUE_221"}])
+
+    set_calls: list[dict[str, object]] = []
+
+    def fake_request(_token: str, query: str, variables: dict[str, object]) -> dict[str, object]:
+        if "query ResolveProject" in query:
+            return _project_payload()
+        if "query ProjectItems" in query:
+            return {
+                "node": {
+                    "items": {
+                        "nodes": [
+                            {
+                                "id": "ITEM_221",
+                                "content": {"__typename": "Issue", "id": "ISSUE_221", "number": 221},
+                                "fieldValues": {
+                                    "nodes": [
+                                        {
+                                            "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                            "name": "Next",
+                                            "optionId": "OPT_NEXT",
+                                            "field": {"name": "Roadmap Lane"},
+                                        },
+                                        {
+                                            "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                            "name": "Done",
+                                            "optionId": "OPT_DONE",
+                                            "field": {"name": "Status"},
+                                        },
+                                    ]
+                                },
+                            }
+                        ],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+        if "mutation AddProjectItem" in query:
+            raise AssertionError("Should not add an existing issue")
+        if "mutation SetSingleSelect" in query:
+            set_calls.append(variables)
+            return {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_221"}}}
+        raise AssertionError(f"Unexpected query: {query[:80]}")
+
+    summary = module.run_sync(
+        token="token",
+        repo=module.RepoRef(owner="Prekzursil", repo="AdrianaArt"),
+        project_owner="Prekzursil",
+        project_number=2,
+        issues_path=issues_path,
+        lane_name="Now",
+        status_name="Todo",
+        dry_run=False,
+        allow_skip_missing_token=False,
+        request_fn=fake_request,
+    )
+
+    assert summary["added"] == 0
+    assert summary["updated"] == 1
+    assert summary["lane_updates"] == 1
+    assert summary["status_updates"] == 0
+    assert len(set_calls) == 1
+    assert set_calls[0]["fieldId"] == "F_LANE"
+
+
+def test_run_sync_dedupes_duplicate_issue_numbers_and_resolves_missing_node_id(tmp_path) -> None:
+    module = _load_module()
+    issues_path = tmp_path / "artifacts" / "audit-evidence" / "severe.json"
+    _write_issues(
+        issues_path,
+        [
+            {"issue_number": 500, "severity": "s2", "route": "/shop"},
+            {"issue_number": 500, "severity": "s2", "route": "/shop", "surface": "storefront"},
+        ],
+    )
+
+    lookup_calls = {"issue_lookup": 0}
+
+    def fake_request(_token: str, query: str, variables: dict[str, object]) -> dict[str, object]:
+        if "query ResolveProject" in query:
+            return _project_payload()
+        if "query ProjectItems" in query:
+            return {
+                "node": {
+                    "items": {
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+        if "query IssueNodeId" in query:
+            lookup_calls["issue_lookup"] += 1
+            return {"repository": {"issue": {"id": "ISSUE_500", "number": 500}}}
+        if "mutation AddProjectItem" in query:
+            return {"addProjectV2ItemById": {"item": {"id": "ITEM_500"}}}
+        if "mutation SetSingleSelect" in query:
+            return {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_500"}}}
+        raise AssertionError(f"Unexpected query: {query[:80]}")
+
+    summary = module.run_sync(
+        token="token",
+        repo=module.RepoRef(owner="Prekzursil", repo="AdrianaArt"),
+        project_owner="Prekzursil",
+        project_number=2,
+        issues_path=issues_path,
+        lane_name="Now",
+        status_name="Todo",
+        dry_run=False,
+        allow_skip_missing_token=False,
+        request_fn=fake_request,
+    )
+
+    assert summary["scanned"] == 1
+    assert summary["added"] == 1
+    assert lookup_calls["issue_lookup"] == 1
+
+
+def test_resolve_project_errors_when_lane_field_missing() -> None:
+    module = _load_module()
+
+    def fake_request(_token: str, _query: str, _variables: dict[str, object]) -> dict[str, object]:
+        return _project_payload(include_lane=False)
+
+    with pytest.raises(RuntimeError, match="Roadmap Lane"):
+        module._resolve_project(
+            token="token",
+            project_owner="Prekzursil",
+            project_number=2,
+            lane_name="Now",
+            status_name="Todo",
+            request_fn=fake_request,
+        )

--- a/scripts/audit/tests/test_upsert_audit_issues_severe_output.py
+++ b/scripts/audit/tests/test_upsert_audit_issues_severe_output.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[1] / "upsert_audit_issues.py"
+    spec = importlib.util.spec_from_file_location("upsert_audit_issues", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_main_writes_severe_output_and_excludes_non_severe(tmp_path, monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "_repo_root", lambda: tmp_path)
+
+    findings_path = tmp_path / "artifacts" / "audit-evidence" / "deterministic-findings.json"
+    findings_path.parent.mkdir(parents=True, exist_ok=True)
+    findings_path.write_text(
+        json.dumps(
+            [
+                {
+                    "fingerprint": "fp-severe",
+                    "severity": "s2",
+                    "title": "Severe finding",
+                    "route": "/shop",
+                    "surface": "storefront",
+                },
+                {
+                    "fingerprint": "fp-low",
+                    "severity": "s3",
+                    "title": "Low finding",
+                    "route": "/about",
+                    "surface": "storefront",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    observed: dict[str, object] = {}
+
+    def fake_upsert(ctx, findings, run_url):
+        observed["count"] = len(findings)
+        observed["fingerprints"] = [row.get("fingerprint") for row in findings]
+        return [
+            {
+                "issue_number": 220,
+                "issue_node_id": "I_kwDO-example",
+                "fingerprint": "fp-severe",
+                "route": "/shop",
+                "surface": "storefront",
+                "severity": "s2",
+                "action": "created",
+            }
+        ]
+
+    monkeypatch.setattr(module, "_upsert_severe", fake_upsert)
+    monkeypatch.setattr(
+        module,
+        "_github_context",
+        lambda _: module.GitHubContext(token="x", owner="Prekzursil", repo="AdrianaArt"),
+    )
+
+    argv = [
+        "upsert_audit_issues.py",
+        "--findings",
+        "artifacts/audit-evidence/deterministic-findings.json",
+        "--severe-output",
+        "artifacts/audit-evidence/severe-issues-upserted.json",
+        "--skip-digest",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    assert module.main() == 0
+    assert observed["count"] == 1
+    assert observed["fingerprints"] == ["fp-severe"]
+
+    severe_output = tmp_path / "artifacts" / "audit-evidence" / "severe-issues-upserted.json"
+    payload = json.loads(severe_output.read_text(encoding="utf-8"))
+    assert payload == [
+        {
+            "issue_number": 220,
+            "issue_node_id": "I_kwDO-example",
+            "fingerprint": "fp-severe",
+            "route": "/shop",
+            "surface": "storefront",
+            "severity": "s2",
+            "action": "created",
+        }
+    ]
+
+
+def test_upsert_severe_returns_updated_entry_for_existing_issue(monkeypatch) -> None:
+    module = _load_module()
+    ctx = module.GitHubContext(token="x", owner="Prekzursil", repo="AdrianaArt")
+
+    marker = "fp-existing"
+    open_issue = {
+        "number": 42,
+        "node_id": "I_kwDO-existing",
+        "title": "old",
+        "body": f"<!-- audit:fingerprint:{marker} -->\nold body",
+    }
+
+    monkeypatch.setattr(module, "_list_open_issues", lambda *_args, **_kwargs: [open_issue])
+
+    calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+    def fake_request(_ctx, method, path, payload=None):
+        calls.append((method, path, payload))
+        return {}
+
+    monkeypatch.setattr(module, "_request", fake_request)
+
+    finding = {
+        "fingerprint": marker,
+        "severity": "s2",
+        "title": "Browser error",
+        "route": "/shop",
+        "surface": "storefront",
+        "labels": ["severity:s2", "surface:storefront"],
+    }
+
+    rows = module._upsert_severe(ctx, [finding], None)
+
+    assert rows == [
+        {
+            "issue_number": 42,
+            "issue_node_id": "I_kwDO-existing",
+            "fingerprint": "fp-existing",
+            "route": "/shop",
+            "surface": "storefront",
+            "severity": "s2",
+            "action": "updated",
+        }
+    ]
+    assert calls
+    assert calls[0][0] == "PATCH"
+    assert calls[0][1].endswith("/issues/42")


### PR DESCRIPTION
## Summary
- complete AI audit phase 2 by syncing severe weekly findings to roadmap project lane `Now`
- add deterministic severe issue handoff output and project sync script
- document Phase 1/2 architecture and runbooks across repo docs
- mark TODO phase 2 complete and add phase 3 follow-up

## Changes
- `scripts/audit/upsert_audit_issues.py`: added `--severe-output` and deterministic severe upsert result payload
- `scripts/audit/sync_severe_issues_to_project.py`: new project sync tool (token-gated, safe-skip mode)
- `.github/workflows/audit-weekly-agent.yml`: writes severe handoff and runs project sync with summary reporting
- docs updates: `docs/AI_AUDIT_PHASES.md`, `README.md`, `CONTRIBUTING.md`, `docs/REPOSITORY_POLICY.md`, `TODO.md`
- tests: new coverage for severe output and project sync edge cases

## Verification
- `python3 -m py_compile scripts/audit/upsert_audit_issues.py scripts/audit/sync_severe_issues_to_project.py backend/app/main.py`
- `python3 -m pytest -q scripts/audit/tests`
- `python3 -m pytest -q scripts/audit/tests/test_upsert_audit_issues_severe_output.py scripts/audit/tests/test_sync_severe_issues_to_project.py`
- `PYTHONPATH=backend backend/.venv/bin/python - <<'PY'`
  - `import app.main`
  - `print('import-ok', hasattr(app.main,'app'))`

## Notes
- If `ROADMAP_PROJECT_WRITE_TOKEN` is missing, weekly sync now skips safely and stays green with an explicit summary reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Severe audit issues now automatically sync to roadmap projects
  * Sentry observability configuration added for backend and frontend monitoring

* **Documentation**
  * Comprehensive AI audit phases documentation added
  * Maintainer weekly triage workflow documented
  * Repository policy and configuration guidelines updated
  * Audit agent watchdog behavior clarified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->