### PR TITLE
fix: avoid empty SENTRY_URL in sentry-release workflow

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -84,10 +84,15 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
-          SENTRY_URL: ${{ steps.config.outputs.url }}
+          SENTRY_URL_INPUT: ${{ steps.config.outputs.url }}
           RELEASE: ${{ steps.config.outputs.release }}
         run: |
           set -euo pipefail
+          if [ -n "${SENTRY_URL_INPUT:-}" ]; then
+            export SENTRY_URL="${SENTRY_URL_INPUT}"
+          else
+            unset SENTRY_URL || true
+          fi
           SENTRY_CLI="npx --yes @sentry/cli@2.57.0"
           ${SENTRY_CLI} releases new "$RELEASE"
           ${SENTRY_CLI} releases set-commits "$RELEASE" --auto


### PR DESCRIPTION
## Summary
- prevent exporting an empty `SENTRY_URL` to `sentry-cli`
- only export `SENTRY_URL` when `vars.SENTRY_URL` is non-empty
- keep SaaS default behavior unchanged when custom URL is not configured

## Why
`Sentry Release` failed on main because `SENTRY_URL` was set to an empty string, causing `bad sentry url: unknown scheme ()`.

## Verification
- workflow YAML parses
- release step now unsets `SENTRY_URL` when it is empty
