### PR TITLE
fix: enable Percy auto-approve with BrowserStack credentials

### DIFF
--- a/.github/workflows/percy-visual.yml
+++ b/.github/workflows/percy-visual.yml
@@ -114,6 +114,8 @@ jobs:
         if: steps.token.outputs.enabled == 'true' && github.event_name == 'pull_request'
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           PERCY_AUTO_APPROVE_PR: ${{ vars.PERCY_AUTO_APPROVE_PR }}
           PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |


### PR DESCRIPTION
### **User description**
## Summary
- update Percy auto-approval helper to support BrowserStack Basic auth for review approval
- keep Percy project-token auth for build lookup compatibility
- wire BrowserStack secrets into  auto-approve step
- add/extend tests for auth-header behavior and limit validation

## Why
Percy build uploads were working in CI, but approval requests returned 403 with token-only auth. BrowserStack review approval requires Basic auth with BrowserStack credentials.

## Verification
- .........                                                                [100%]
9 passed in 0.03s
- ................................                                         [100%]
32 passed in 0.12s
-


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add BrowserStack Basic auth support for Percy review approval requests

- Refactor `_request_json()` to support both token and basic auth methods

- Wire BrowserStack credentials into CI workflow auto-approve step

- Extend test coverage for auth headers and validation logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Percy Auto-Approve Script"] -->|"Token Auth"| B["Build Lookup"]
  A -->|"BrowserStack Basic Auth"| C["Review Approval"]
  D["CI Workflow"] -->|"PERCY_TOKEN"| A
  D -->|"BROWSERSTACK_USERNAME<br/>BROWSERSTACK_ACCESS_KEY"| A
  C -->|"Success"| E["Build Approved"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>percy_auto_approve.py</strong><dd><code>Add BrowserStack Basic auth for review approval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/audit/percy_auto_approve.py

<ul><li>Import <code>base64</code> module for encoding Basic auth credentials<br> <li> Refactor <code>_request_json()</code> to accept optional <code>basic_auth</code> parameter <br>alongside token<br> <li> Implement conditional auth header logic: use Basic auth if provided, <br>otherwise fall back to token auth<br> <li> Add <code>browserstack_username</code> and <code>browserstack_access_key</code> parameters to <br><code>run()</code> function<br> <li> Update approval request to use BrowserStack Basic auth when <br>credentials are available<br> <li> Add error handling with try-except for approval requests and output <br>error details<br> <li> Extend argument parser to accept BrowserStack credentials from CLI or <br>environment variables<br> <li> Update <code>main()</code> to extract and pass BrowserStack credentials to <code>run()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Prekzursil/AdrianaArt/pull/417/files#diff-189f6c807d6796cbb1f66f12fc6358652073edb56082475958e8a5043778df57">+76/-32</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_percy_auto_approve.py</strong><dd><code>Add tests for auth header behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/audit/tests/test_percy_auto_approve.py

<ul><li>Add imports for <code>base64</code> and <code>pytest</code> modules<br> <li> Refactor <code>test_run_rejects_non_positive_limit()</code> to use <code>pytest.raises()</code> <br>context manager<br> <li> Add <code>test_request_json_uses_token_auth_and_omits_content_type_for_get()</code> <br>to verify token auth header and conditional Content-Type header<br> <li> Add <code>test_request_json_uses_basic_auth_for_review_post()</code> to verify <br>Basic auth header encoding and Content-Type inclusion</ul>


</details>


  </td>
  <td><a href="https://github.com/Prekzursil/AdrianaArt/pull/417/files#diff-8307dd3e2625e4d42f6cd1b03723fc4b6575f4d61893fcbb0c50bf1681e31054">+77/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>percy-visual.yml</strong><dd><code>Wire BrowserStack secrets to CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/percy-visual.yml

<ul><li>Add <code>BROWSERSTACK_USERNAME</code> secret to auto-approve step environment<br> <li> Add <code>BROWSERSTACK_ACCESS_KEY</code> secret to auto-approve step environment</ul>


</details>


  </td>
  <td><a href="https://github.com/Prekzursil/AdrianaArt/pull/417/files#diff-f83cddf1f1dccc073b3e844d0ce0efd6c9ad9239bd0bcd11f6b30e68010cc8c5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BrowserStack credentials support for Percy visual review auto-approvals as an alternative to token-based authentication
  * Flexible authentication: supports both token and BrowserStack credential-based authentication methods
  * Environment variables (BROWSERSTACK_USERNAME, BROWSERSTACK_ACCESS_KEY) and command-line arguments now available for credential configuration
  * Improved error handling and logging in the approval workflow

* **Tests**
  * Added test coverage for authentication methods and HTTP request handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->