### PR TITLE
infra(prod): make app/domain/systemd identifiers env-driven

### DIFF
--- a/infra/prod/.env.example
+++ b/infra/prod/.env.example
@@ -2,13 +2,20 @@
 #
 # This file is used by:
 # - docker compose variable substitution (POSTGRES_PASSWORD, etc.)
-# - Caddyfile placeholders (CADDY_EMAIL)
+# - Caddyfile placeholders (PUBLIC_DOMAIN, CADDY_EMAIL)
+# - infra/prod/*.sh helper defaults (APP_SLUG, SYSTEMD_SERVICE_PREFIX)
 #
 # Keep infra/prod/.env out of git (already ignored via .gitignore).
 
-# --- Public site ---
-# Domain served by Caddy (TLS is issued for both apex + www).
+# --- Template identity ---
+# Base slug used by deploy scripts when names are not explicitly overridden.
+APP_SLUG=momentstudio
+# Public apex domain served by Caddy (TLS is issued for both apex + www).
 PUBLIC_DOMAIN=momentstudio.ro
+# Prefix for generated systemd units (defaults to APP_SLUG when omitted).
+SYSTEMD_SERVICE_PREFIX=momentstudio
+# Compose project name; keep this aligned with APP_SLUG to avoid mismatched operations.
+COMPOSE_PROJECT_NAME=momentstudio
 
 # Email used by Let's Encrypt / ACME (recommended).
 # Example: admin@momentstudio.ro
@@ -40,9 +47,6 @@ REDIS_URL=
 # If your reverse proxy / load balancer uses a public IP (or runs outside these CIDRs), you MUST
 # set this explicitly to the proxy IPs/CIDRs that connect to the backend.
 FORWARDED_ALLOW_IPS=127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-
-# Optional: make container names stable across multiple projects on the same VPS.
-COMPOSE_PROJECT_NAME=momentstudio
 
 # Optional: static app version shown in diagnostics.
 # Normally omitted because `infra/prod/deploy.sh` auto-sets APP_VERSION from git SHA.

--- a/infra/prod/Caddyfile
+++ b/infra/prod/Caddyfile
@@ -8,7 +8,7 @@ www.{$PUBLIC_DOMAIN} {
 	redir https://{$PUBLIC_DOMAIN}{uri} permanent
 }
 
-# momentstudio.ro (production)
+# {$PUBLIC_DOMAIN} (production)
 {$PUBLIC_DOMAIN} {
 	encode zstd gzip
 

--- a/infra/prod/deploy.sh
+++ b/infra/prod/deploy.sh
@@ -7,6 +7,18 @@ env_file="${repo_root}/infra/prod/.env"
 
 cd "${repo_root}"
 
+if [[ -f "${env_file}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${env_file}"
+  set +a
+fi
+
+APP_SLUG="${APP_SLUG:-momentstudio}"
+PUBLIC_DOMAIN="${PUBLIC_DOMAIN:-momentstudio.ro}"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-${APP_SLUG}}"
+export APP_SLUG PUBLIC_DOMAIN COMPOSE_PROJECT_NAME
+
 if ! command -v docker >/dev/null 2>&1; then
   echo "ERROR: docker is not installed. See infra/prod/README.md" >&2
   exit 1
@@ -43,7 +55,7 @@ if [[ -z "${APP_VERSION:-}" ]]; then
   export APP_VERSION
 fi
 
-echo "Starting (or updating) momentstudio production stack..."
+echo "Starting (or updating) ${APP_SLUG} production stack..."
 docker compose --env-file "${env_file}" -f "${compose_file}" up -d --build
 
 if [[ "${RUN_DB_MIGRATIONS_ON_DEPLOY:-1}" == "1" ]]; then

--- a/infra/prod/install-backup-timer.sh
+++ b/infra/prod/install-backup-timer.sh
@@ -7,12 +7,28 @@ if [[ "${EUID}" -ne 0 ]]; then
 fi
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-service_path="/etc/systemd/system/momentstudio-backup.service"
-timer_path="/etc/systemd/system/momentstudio-backup.timer"
+env_file="${repo_root}/infra/prod/.env"
+
+if [[ -f "${env_file}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${env_file}"
+  set +a
+fi
+
+APP_SLUG="${APP_SLUG:-momentstudio}"
+SYSTEMD_SERVICE_PREFIX="${SYSTEMD_SERVICE_PREFIX:-${APP_SLUG}}"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-${APP_SLUG}}"
+export APP_SLUG SYSTEMD_SERVICE_PREFIX COMPOSE_PROJECT_NAME
+
+service_name="${SYSTEMD_SERVICE_PREFIX}-backup.service"
+timer_name="${SYSTEMD_SERVICE_PREFIX}-backup.timer"
+service_path="/etc/systemd/system/${service_name}"
+timer_path="/etc/systemd/system/${timer_name}"
 
 cat >"${service_path}" <<EOF
 [Unit]
-Description=momentstudio backup (DB + media)
+Description=${APP_SLUG} backup (DB + media)
 Wants=network-online.target
 After=network-online.target docker.service
 Requires=docker.service
@@ -25,7 +41,7 @@ EOF
 
 cat >"${timer_path}" <<EOF
 [Unit]
-Description=Run momentstudio backups daily
+Description=Run ${APP_SLUG} backups daily
 
 [Timer]
 OnCalendar=daily
@@ -39,15 +55,15 @@ EOF
 echo "Installing systemd units:"
 echo "- ${service_path}"
 echo "- ${timer_path}"
+echo "Using APP_SLUG=${APP_SLUG}, COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}, SYSTEMD_SERVICE_PREFIX=${SYSTEMD_SERVICE_PREFIX}"
 
 systemctl daemon-reload
-systemctl enable --now momentstudio-backup.timer
+systemctl enable --now "${timer_name}"
 
 echo
 echo "Timer status:"
-systemctl status momentstudio-backup.timer --no-pager
+systemctl status "${timer_name}" --no-pager
 
 echo
 echo "Tip: view backup logs with:"
-echo "  journalctl -u momentstudio-backup.service -n 200 --no-pager"
-
+echo "  journalctl -u ${service_name} -n 200 --no-pager"

--- a/infra/prod/request-indexing-checklist.sh
+++ b/infra/prod/request-indexing-checklist.sh
@@ -32,6 +32,7 @@ if [[ -z "${PUBLIC_DOMAIN:-}" ]]; then
   PUBLIC_DOMAIN="$(read_env_var "PUBLIC_DOMAIN" "${env_file}")"
 fi
 PUBLIC_DOMAIN="${PUBLIC_DOMAIN:-momentstudio.ro}"
+APP_SLUG="${APP_SLUG:-momentstudio}"
 
 verify_base_url="${VERIFY_BASE_URL:-https://${PUBLIC_DOMAIN}}"
 verify_base_url="${verify_base_url%/}"
@@ -64,7 +65,7 @@ if [[ -n "${product_slug}" ]]; then
   urls+=("${verify_base_url}/products/${product_slug}?lang=ro")
 fi
 
-echo "Search Console post-deploy indexing checklist"
+echo "Search Console post-deploy indexing checklist (${APP_SLUG})"
 echo "Property: ${PUBLIC_DOMAIN}"
 echo "Base URL: ${verify_base_url}"
 echo

--- a/infra/prod/start.sh
+++ b/infra/prod/start.sh
@@ -22,13 +22,23 @@ if [[ ! -f "${env_file}" ]]; then
   exit 1
 fi
 
+set -a
+# shellcheck disable=SC1090
+source "${env_file}"
+set +a
+
+APP_SLUG="${APP_SLUG:-momentstudio}"
+PUBLIC_DOMAIN="${PUBLIC_DOMAIN:-momentstudio.ro}"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-${APP_SLUG}}"
+export APP_SLUG PUBLIC_DOMAIN COMPOSE_PROJECT_NAME
+
 # Stamp runtime config with the deployed git revision unless overridden.
 if [[ -z "${APP_VERSION:-}" ]]; then
   APP_VERSION="$(git rev-parse --short HEAD)"
   export APP_VERSION
 fi
 
-echo "Starting momentstudio production stack (no rebuild)..."
+echo "Starting ${APP_SLUG} production stack (no rebuild)..."
 docker compose --env-file "${env_file}" -f "${compose_file}" up -d --no-build "$@"
 
 echo

--- a/infra/prod/stop.sh
+++ b/infra/prod/stop.sh
@@ -22,9 +22,17 @@ if [[ ! -f "${env_file}" ]]; then
   exit 1
 fi
 
-echo "Stopping momentstudio production stack (keeps volumes/data)..."
+set -a
+# shellcheck disable=SC1090
+source "${env_file}"
+set +a
+
+APP_SLUG="${APP_SLUG:-momentstudio}"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-${APP_SLUG}}"
+export APP_SLUG COMPOSE_PROJECT_NAME
+
+echo "Stopping ${APP_SLUG} production stack (keeps volumes/data)..."
 docker compose --env-file "${env_file}" -f "${compose_file}" stop "$@"
 
 echo
 docker compose --env-file "${env_file}" -f "${compose_file}" ps
-

--- a/infra/prod/systemd/momentstudio-backup.service.example
+++ b/infra/prod/systemd/momentstudio-backup.service.example
@@ -1,12 +1,11 @@
 [Unit]
-Description=momentstudio backup (DB + media)
+Description=<APP_SLUG> backup (DB + media)
 Wants=network-online.target
 After=network-online.target docker.service
 Requires=docker.service
 
 [Service]
 Type=oneshot
-# Update this path to match your deploy directory (example: /opt/momentstudio).
-WorkingDirectory=/opt/momentstudio
-ExecStart=/opt/momentstudio/infra/prod/backup.sh
-
+# Update this path to match your deploy directory (example: /opt/<APP_SLUG>). 
+WorkingDirectory=/opt/<APP_SLUG>
+ExecStart=/opt/<APP_SLUG>/infra/prod/backup.sh

--- a/infra/prod/systemd/momentstudio-backup.timer
+++ b/infra/prod/systemd/momentstudio-backup.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run momentstudio backups daily
+Description=Run <APP_SLUG> backups daily
 
 [Timer]
 OnCalendar=daily
@@ -8,4 +8,3 @@ RandomizedDelaySec=15m
 
 [Install]
 WantedBy=timers.target
-

--- a/infra/prod/verify-live.sh
+++ b/infra/prod/verify-live.sh
@@ -23,6 +23,7 @@ if [[ -z "${PUBLIC_DOMAIN:-}" ]]; then
   PUBLIC_DOMAIN="$(read_env_var "PUBLIC_DOMAIN" "${env_file}")"
 fi
 PUBLIC_DOMAIN="${PUBLIC_DOMAIN:-momentstudio.ro}"
+APP_SLUG="${APP_SLUG:-momentstudio}"
 
 verify_base_url="${VERIFY_BASE_URL:-https://${PUBLIC_DOMAIN}}"
 expected_manifest_mime="${VERIFY_MANIFEST_MIME:-application/manifest+json}"
@@ -60,7 +61,7 @@ extract_header() {
     | head -n 1
 }
 
-echo "Verifying production endpoints at ${verify_base_url}"
+echo "Verifying ${APP_SLUG} production endpoints at ${verify_base_url}"
 
 if curl -fsS "${verify_base_url}/api/v1/health" >/dev/null; then
   pass "GET /api/v1/health"


### PR DESCRIPTION
### Motivation
- Remove hardcoded app/domain/service identifiers in the prod deploy tooling and make them configurable via env vars so the infra is template-friendly while preserving current behavior by default.
- Ensure composed Docker project naming and generated systemd unit names derive from the same slug/prefix to avoid mismatched operations when multiple stacks are hosted on a single host.

### Description
- Introduced `APP_SLUG`, `PUBLIC_DOMAIN`, and `COMPOSE_PROJECT_NAME` usage across `infra/prod/*` helper scripts and defaulted them to existing values (`momentstudio` / `momentstudio.ro`) when not provided, and exported them for downstream tools.
- Added `SYSTEMD_SERVICE_PREFIX` (defaulting to `APP_SLUG`) and updated `infra/prod/install-backup-timer.sh` to generate systemd unit/timer names from that prefix, and to print the resolved identity values when installing.
- Updated templates/docs: `infra/prod/.env.example` now documents `APP_SLUG`, `PUBLIC_DOMAIN`, `SYSTEMD_SERVICE_PREFIX`, and `COMPOSE_PROJECT_NAME`, `infra/prod/README.md` was rewritten with template placeholders, `infra/prod/Caddyfile` comment adjusted, and systemd example unit/timer files generalized to `<APP_SLUG>` placeholders.
- Adjusted verification and checklist scripts to read `PUBLIC_DOMAIN`/`APP_SLUG` from env and show the slug in output messages; updated `deploy.sh`/`start.sh`/`stop.sh` to source `.env` when present and surface `APP_SLUG` in log messages.

Files touched (examples): `infra/prod/deploy.sh`, `infra/prod/start.sh`, `infra/prod/stop.sh`, `infra/prod/install-backup-timer.sh`, `infra/prod/verify-live.sh`, `infra/prod/request-indexing-checklist.sh`, `infra/prod/Caddyfile`, `infra/prod/.env.example`, `infra/prod/README.md`, `infra/prod/systemd/*`.

### Testing
- Verified shell syntax for updated helpers with `bash -n` across `infra/prod/deploy.sh`, `start.sh`, `stop.sh`, `verify-live.sh`, `request-indexing-checklist.sh`, and `install-backup-timer.sh`, which returned no syntax errors.
- Ran the repository verification `make verify`, which failed due to an existing, unrelated backend type-check error (`mypy` error in `app/services/netopia.py` complaining about missing `types-simplejson` stubs), so overall infra script changes did not block verification but the full `make verify` remains failing for unrelated reasons.
- Performed a local commit for these changes; `bash -n` checks passed for modified scripts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a05ff2a3c8332af0e389caa49bc9e)