### PR TITLE
chore(ci): reconcile biome formatter with the project's Prettier config

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "files": {
+    "includes": [
+      "**/*.ts",
+      "**/*.tsx",
+      "**/*.js",
+      "**/*.jsx",
+      "**/*.mjs",
+      "**/*.cjs",
+      "!**/node_modules/**",
+      "!**/dist/**",
+      "!**/build/**",
+      "!**/out/**",
+      "!**/.venv/**",
+      "!**/vendor/**"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "lineEnding": "lf"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "all",
+      "semicolons": "always"
+    }
+  },
+  "linter": { "enabled": false },
+  "assist": { "enabled": false }
+}


### PR DESCRIPTION
## Problem

The shared `quality-zero-platform` gate format-checks ts/js with **biome 2.5.0**. With no repo-level biome config, biome fell back to its **own defaults** — double quotes, tab indentation, `lineWidth 80` — which disagree with the project's Prettier config (`frontend/prettier.config.cjs`: `singleQuote`, `trailingComma: 'all'`, `semi`, `printWidth: 100`). PRs then failed the gate's biome format-check on files Prettier considers clean, which would block the upcoming site-builder P1a PRs.

### Confirmed conflicts (biome default vs the project)

Running biome with its defaults against a real frontend file reproduces exactly three disagreements:

| Rule | Prettier (project) | biome default | 
|---|---|---|
| Quote style | `'@angular/core'` (single) | `"@angular/core"` (double) |
| Indentation | 2 spaces | tabs |
| Line width | `printWidth: 100` (kept on one line) | `80` (wrapped `Array<{…}>` onto multiple lines) |

## Fix

Add a repo-root **`biome.json`** whose formatter options mirror the Prettier config so the two tools agree byte-for-byte:

| biome option | value | mirrors Prettier |
|---|---|---|
| `formatter.indentStyle` / `indentWidth` | `space` / `2` | default `tabWidth: 2`, no tabs |
| `formatter.lineWidth` | `100` | `printWidth: 100` |
| `formatter.lineEnding` | `lf` | Prettier default |
| `javascript.formatter.quoteStyle` | `single` | `singleQuote: true` |
| `javascript.formatter.trailingCommas` | `all` | `trailingComma: 'all'` |
| `javascript.formatter.semicolons` | `always` | `semi: true` |

It is **formatter-only** (`linter` and `assist` disabled) so this reconciles **formatting only** — it does not switch on biome's linter alongside the project's existing ESLint/Oxlint, and it weakens no lint rules.

## Why this is the right seam

The lean gate explicitly **honors a caller-shipped `biome.json`** (biome auto-discovers it from cwd; otherwise it falls back to the bundled template). Qlty's biome plugin reads the same file. So a repo-root `biome.json` is the intended, least-invasive override point — no gate/workflow edits required.

## Verification

- `biome ci` (auto-discovering the new `biome.json`) over the **whole repo**: `Checked 369 files … No fixes applied` — the codebase is already clean under these options, so **nothing is reformatted**.
- `prettier --check` on sampled frontend files: `All matched files use Prettier code style!`
- **Round-trip stable**: `biome format --write` then `prettier --check` → clean; `prettier --write` then `biome ci` → clean; and biome-formatted vs prettier-formatted output of the previously-divergent file is **byte-identical**.

https://claude.ai/code/session_01TTkqbh6EUgNAAqsePAmHz9