### PR TITLE
ci: forward Chromatic/Applitools/Codex secrets to scanner-matrix

### DIFF
--- a/.github/workflows/quality-zero-platform.yml
+++ b/.github/workflows/quality-zero-platform.yml
@@ -35,5 +35,8 @@ jobs:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       DEEPSCAN_API_TOKEN: ${{ secrets.DEEPSCAN_API_TOKEN }}


### PR DESCRIPTION
## Problem / Outcome

The `shared-scanner-matrix` job in `.github/workflows/quality-zero-platform.yml` calls the reusable `Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@d7a94db`, whose `on.workflow_call.secrets` **declares 8 secrets**. The caller only forwarded **5** of them, silently omitting:

- `CHROMATIC_PROJECT_TOKEN`
- `APPLITOOLS_API_KEY`
- `CODEX_AUTH_JSON`

All three **exist as repository secrets** (set in March), but because they were never handed to the reusable workflow, the **Quality Secrets Preflight** lane reported them as *missing* and hard-failed — which also cascades into the `Quality Rollup` and `Quality Zero Gate` aggregators and blocks the Applitools Visual lane.

This PR forwards the three genuinely-present secrets to the gate that checks for them.

## Scope and Success Criteria

- **In scope:** wiring the three declared-but-unforwarded secrets so `Quality Secrets Preflight` sees reality.
- **Out of scope (separate, larger/out-of-repo work — see below):** frontend coverage, SonarCloud issue backlog, QLTY complexity, DeepScan SaaS status.
- **Success:** `Quality Secrets Preflight` no longer reports these three as missing; Applitools lane can run.

## What this does NOT do

This is **not** a gate weakening or bypass — no threshold is lowered and no provider is dropped. It only delivers secrets that already exist to the workflow that already declares them.

It also does **not** turn the whole QZP gate green on its own. The following remain red and require separate work (reported to the maintainer, not fixed here):

- **Frontend coverage ~50% vs the deliberate 100% floor** (`frontend/karma.conf.cjs` enforces global 100% by design) — blocks `Coverage 100 Gate`, `quality/quality`, and the `Codecov`/`Codacy` coverage-upload chain. This is a substantial test-writing effort across ~215 source files, not a config change.
- **~598 open SonarCloud issues + a stale HEAD scan** (analysis pinned to an older SHA) — real findings plus a scan-publish gap.
- **QLTY complexity/duplication smells** (mostly in `scripts/audit/`).
- **DeepScan SaaS posting a `failure` commit-status** — external dashboard/integration.

## Evidence

- YAML validated; all 8 declared secrets now forwarded (verified against the reusable workflow's `on.workflow_call.secrets` at pinned SHA `d7a94db`).
- Single-file, additive change (3 lines).

## Risk

`low` — additive secret forwarding to an existing reusable-workflow call. No logic, code, or threshold change.

https://claude.ai/code/session_01TTkqbh6EUgNAAqsePAmHz9