### PR TITLE
test(frontend): de-flake leaflet chunk-load + interceptor/courier specs

### DIFF
--- a/frontend/src/app/core/http.interceptor.spec.ts
+++ b/frontend/src/app/core/http.interceptor.spec.ts
@@ -1,6 +1,10 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClient, HttpHeaders, provideHttpClient, withInterceptors } from '@angular/common/http';
-import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import {
+  provideHttpClientTesting,
+  HttpTestingController,
+  TestRequest,
+} from '@angular/common/http/testing';
 import { of, throwError } from 'rxjs';
 
 import { authAndErrorInterceptor } from './http.interceptor';
@@ -198,11 +202,20 @@ describe('authAndErrorInterceptor', () => {
           new Blob([JSON.stringify({ code: 'step_up_required' })], { type: 'application/json' }),
           { status: 403, statusText: 'Forbidden' },
         );
-      // Blob.text() resolves on a real microtask queue; wait for it.
-      await new Promise<void>((resolve) => setTimeout(resolve, 10));
-      const retry = httpMock.expectOne('/api/v1/newsletter/admin/export');
-      expect(retry.request.headers.get('X-Admin-Step-Up')).toBe('stepBLOB');
-      retry.flush(new Blob(['ok']));
+      // Blob.text() resolves on a real microtask queue outside fakeAsync/Zone
+      // control, so poll for the dispatched retry request instead of racing a
+      // fixed timeout (which is flaky on a loaded CI runner). Capture the request
+      // from match() so we never do a second, consuming lookup.
+      let retry: TestRequest | undefined;
+      for (let i = 0; i < 100 && !retry; i++) {
+        retry = httpMock.match('/api/v1/newsletter/admin/export')[0];
+        if (!retry) {
+          await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        }
+      }
+      expect(retry).toBeDefined();
+      expect(retry!.request.headers.get('X-Admin-Step-Up')).toBe('stepBLOB');
+      retry!.flush(new Blob(['ok']));
     });
 
     it('reads the step-up code from an ArrayBuffer body', fakeAsync(() => {

--- a/frontend/src/app/shared/locker-picker.component.spec.ts
+++ b/frontend/src/app/shared/locker-picker.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
+import * as L from 'leaflet';
 import { of, throwError } from 'rxjs';
 
 import { LazyStylesService } from '../core/lazy-styles.service';
@@ -15,6 +16,7 @@ type Private = {
   mapHost?: { nativeElement: HTMLDivElement };
   searchTimer: number | null;
   searchAbort: AbortController | null;
+  loadLeaflet: () => Promise<typeof import('leaflet')>;
   fetchLocations: (q: string, opts?: { applyFirst?: boolean }) => Promise<void>;
   loadLockers: (lat: number, lng: number) => Promise<void>;
   refreshMirrorSnapshot: () => Promise<void>;
@@ -551,6 +553,10 @@ describe('LockerPickerComponent', () => {
   it('builds a real map and reacts to its events and markers', async () => {
     const fixture = make();
     const cmp = fixture.componentInstance;
+    // Feed the eagerly-bundled Leaflet module through the import seam so this
+    // integration test drives a real map without performing a network-backed
+    // lazy chunk fetch (the source of the intermittent ChunkLoadError).
+    spyOn(priv(fixture), 'loadLeaflet').and.returnValue(Promise.resolve(L));
     const host = document.createElement('div');
     host.style.width = '300px';
     host.style.height = '200px';
@@ -604,5 +610,14 @@ describe('LockerPickerComponent', () => {
     priv(fixture).mapHost = undefined;
     await cmp.initMap();
     expect(priv(fixture).map).toBeNull();
+  });
+
+  it('loadLeaflet resolves the Leaflet module through the import seam', async () => {
+    const fixture = make();
+    // Exercises the real seam body. Because the spec statically imports Leaflet,
+    // webpack bundles it eagerly, so this dynamic import resolves from the test
+    // bundle rather than fetching a lazy runtime chunk over HTTP.
+    const mod = await priv(fixture).loadLeaflet();
+    expect(mod.map).toBe(L.map);
   });
 });

--- a/frontend/src/app/shared/locker-picker.component.ts
+++ b/frontend/src/app/shared/locker-picker.component.ts
@@ -300,12 +300,23 @@ export class LockerPickerComponent implements AfterViewInit, OnChanges, OnDestro
     return `${item.lat},${item.lng},${item.display_name}`;
   }
 
+  /**
+   * Seam for the lazy Leaflet import. Isolated into an overridable method so
+   * tests can supply an eagerly-bundled Leaflet module instead of triggering a
+   * network-backed webpack lazy chunk, which times out intermittently under
+   * headless Chrome on a loaded CI runner and surfaced as a ChunkLoadError
+   * attributed to whichever spec happened to be draining the microtask queue.
+   */
+  protected loadLeaflet(): Promise<Leaflet> {
+    return import('leaflet');
+  }
+
   async initMap(): Promise<void> {
     if (this.initialized) return;
     if (!this.mapHost?.nativeElement) return;
 
     await this.styles.ensure('leaflet', 'assets/vendor/leaflet/leaflet.css');
-    const L = await import('leaflet');
+    const L = await this.loadLeaflet();
     this.leaflet = L;
 
     const map = L.map(this.mapHost.nativeElement, { zoomControl: true }).setView(


### PR DESCRIPTION
## Problem

Three frontend Karma specs failed intermittently in CI. The common multiplier is Jasmine's **default `random: true`** spec ordering (neither `karma.conf.cjs` nor `test.ts` disables it), which lets async/global state from one spec surface as a failure in an unrelated spec.

## Fixes (deterministic, coverage-preserving)

### 1. `LockerPicker` — `ChunkLoadError` (leaflet)
`initMap()` ran `await import('leaflet')` — a real, network-backed webpack **lazy chunk**. Under `ChromeHeadlessNoSandbox` on a loaded runner the fetch intermittently timed out; because the rejection is effectively global and specs run in random order, Karma attributed it to whichever spec was draining the microtask queue (frequently the `fakeAsync` debounce spec, which never touches leaflet).

- Extract an overridable `loadLeaflet()` seam in the component.
- The spec now `import * as L from 'leaflet'` **statically**, so webpack bundles leaflet **eagerly** into the test bundle instead of serving a lazy runtime chunk.
- The real-map integration spec feeds that eager module through the seam; a focused spec covers the seam body. **No unit spec performs a runtime chunk fetch anymore.**

### 2. Interceptor — blob step-up retry race
The success-path spec waited a fixed `setTimeout(_, 10)` for the real (non-`fakeAsync`) `Blob.text()` read, then asserted the retry request existed — a race that failed when the read took longer on a loaded runner. Replaced with the **same bounded poll** the sibling blob specs already use, waiting on the terminal condition (retry dispatched) and capturing it from the single consuming `match()` call (`match()` splices matched requests out of the queue, so a second `expectOne` would find none).

### 3. `SuccessComponent > courierLabel`
No `success.component.spec.ts` exists at HEAD (`grep SuccessComponent **/*.spec.ts` → none), so there is **no collected test to fix**. `courierLabel()` is pure/synchronous and cannot be intrinsically flaky; the historical flake vector was global `history.state` pollution under random ordering. No source bug found; nothing to change without inventing a test outside this PR's scope.

## Verification

- Affected specs: **74/74 SUCCESS** in isolation, repeated under randomized order with zero failures/disconnects.
- `locker-picker.component.ts` (the only source change) is **100%** on lines/branches/functions/statements after the change.
- Full-suite 100% coverage gate is enforced on CI (Linux); it could not complete locally on Windows because headless Chrome hit a ping-timeout under memory pressure at ~1640/1779 (all executed tests SUCCESS) — an environment limit, not a regression.

No assertions weakened, no tests skipped or removed.

https://claude.ai/code/session_01TTkqbh6EUgNAAqsePAmHz9
