### PR TITLE
fix: harden theme_validation regex against ReDoS (CodeQL #1093)

### DIFF
--- a/backend/app/services/theme_validation.py
+++ b/backend/app/services/theme_validation.py
@@ -62,10 +62,21 @@ _SCHEME = re.compile(r"^[a-z][a-z0-9+.-]*:", re.IGNORECASE)
 _HEX_ESCAPE = re.compile(r"\\([0-9a-fA-F]{1,6})[ \t\n\f\r]?")
 _LITERAL_ESCAPE = re.compile(r"\\([^0-9a-fA-F])")
 _CONTROL = re.compile(r"[\x00-\x1f\x7f]")
-# ``\s``-excluded target class so the surrounding ``\s*`` cannot overlap it —
-# prevents polynomial backtracking (ReDoS) on ``url(`` + many spaces. Mirrors
-# the frontend css-safe-encode URL_CALL.
-_URL_CALL = re.compile(r"url\(\s*(['\"]?)([^'\")\s]*)\1\s*\)", re.IGNORECASE)
+# URL-target class excludes quotes, ``)``, ``(`` AND whitespace, matched
+# possessively (``*+``). Two guarantees flow from this:
+#   1. Linear time — the scan stops at the next ``(`` instead of running to
+#      end-of-input and then backtracking, so ``url(`` followed by many ``url(!``
+#      repetitions can no longer drive polynomial backtracking (CodeQL
+#      py/polynomial-redos). The possessive ``*+`` additionally forbids ALL
+#      backtracking into the class (its followers ``\1``/``\s*``/``\)`` are
+#      disjoint from it, so this never changes what is matched).
+#   2. Correctness — an unquoted ``url()`` value cannot contain an unescaped
+#      ``(`` per the CSS url-token grammar, so excluding it only ever rejects
+#      values that were already invalid CSS; every legitimate (spec-valid) value
+#      classifies identically to before.
+# Mirrors the frontend css-safe-encode URL_CALL (same class; JS has no possessive
+# quantifier, but excluding ``(`` alone is linear and match-equivalent there).
+_URL_CALL = re.compile(r"url\(\s*(['\"]?)([^'\")(\s]*+)\1\s*\)", re.IGNORECASE)
 
 
 @dataclass(frozen=True)

--- a/backend/tests/test_theme_validation.py
+++ b/backend/tests/test_theme_validation.py
@@ -13,6 +13,7 @@ the CSS-escape decoder edge cases.
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 import pytest
@@ -253,3 +254,33 @@ def test_encode_css_safe_url_allowlist() -> None:
     ok_result = encode_css_safe("15 23 42", allow_url=True)
     assert ok_result.ok is True
     assert ok_result.value == "15 23 42"
+
+
+def test_encode_css_safe_url_matching_is_linear_not_redos() -> None:
+    # Regression for CodeQL py/polynomial-redos: a ``url(`` prefix followed by
+    # many ``url(!`` repetitions previously drove polynomial backtracking in the
+    # ``_URL_CALL`` scan (the greedy target class ran to end-of-input at every
+    # ``url(`` start, then backtracked hunting for a closing ``)``). The hardened
+    # pattern (possessive quantifier + a target class that also excludes ``(``)
+    # is linear, so this ~100k-char pathological input resolves near-instantly and
+    # still hard-rejects (no closing ``)`` -> no match -> reject). A generous 1s
+    # budget flags a regression (the vulnerable form takes many seconds here)
+    # without being flaky (the fixed form is single-digit milliseconds).
+    pathological = "url(" + "url(!" * 20000
+    start = time.perf_counter()
+    result = encode_css_safe(pathological, allow_url=True)
+    elapsed = time.perf_counter() - start
+    assert result.ok is False
+    assert elapsed < 1.0, f"url() scan took {elapsed:.3f}s — possible ReDoS regression"
+
+
+def test_encode_css_safe_url_rejects_unescaped_paren_target() -> None:
+    # The hardened target class excludes ``(`` to match the CSS url-token grammar
+    # (an unquoted ``url()`` value cannot contain an unescaped ``(``), so such
+    # already-invalid values hard-reject (the scan finds no complete ``url(...)``).
+    # This is a strict tightening on invalid CSS only; spec-valid targets below
+    # still validate exactly as before.
+    assert encode_css_safe("url(https://a.com/a(b).png)", allow_url=True).ok is False
+    assert encode_css_safe("url(a(b))", allow_url=True).ok is False
+    assert encode_css_safe("url(https://a.com/a-b.png)", allow_url=True).ok is True
+    assert encode_css_safe("url(/self/a-b.woff2)", allow_url=True).ok is True

--- a/frontend/src/app/core/theme/css-safe-encode.ts
+++ b/frontend/src/app/core/theme/css-safe-encode.ts
@@ -18,10 +18,15 @@
 
 const HEX_ESCAPE = /\\([0-9a-fA-F]{1,6})[ \t\n\f\r]?/g;
 const LITERAL_ESCAPE = /\\([^0-9a-fA-F])/g;
-// Excludes whitespace from the URL-target class so the surrounding `\s*` cannot
-// overlap it — prevents polynomial backtracking (ReDoS) on `url(` + many spaces.
-// Valid URLs carry no unescaped whitespace, so a spaced target correctly fails.
-const URL_CALL = /url\(\s*(['"]?)([^'")\s]*)\1\s*\)/gi;
+// URL-target class excludes quotes, `)`, `(` and whitespace. Excluding `(`
+// mirrors the CSS url-token grammar (an unquoted `url()` value cannot contain an
+// unescaped `(`) and keeps matching linear: the scan stops at the next `(`
+// instead of running to end-of-input and backtracking, so `url(` followed by
+// many `url(!` repetitions can no longer drive polynomial backtracking (ReDoS).
+// Mirrors the backend theme_validation `_URL_CALL` (which additionally matches
+// the class possessively; JS has no possessive quantifier, but the `(` exclusion
+// alone is linear and match-equivalent — a spaced/`(`-bearing target still fails).
+const URL_CALL = /url\(\s*(['"]?)([^'")(\s]*)\1\s*\)/gi;
 const SCHEME = /^[a-z][a-z0-9+.-]*:/i;
 
 /** True if the value contains a C0 control character or DEL (0x00-0x1f, 0x7f). */


### PR DESCRIPTION
## Summary

Fixes CodeQL alert **#1093 `py/polynomial-redos`** (HIGH) at `backend/app/services/theme_validation.py` — a regular-expression denial-of-service (polynomial backtracking) in the shared theme-token CSS-safe encoder (`_URL_CALL`, used at the `finditer` on line 167).

**Propose-only — please do not merge without review.** This is a payments/storefront app.

## The vulnerability

`encode_css_safe(...)` extracts every `url(...)` in a token value with `_URL_CALL` and checks each target against the `https:`/self allowlist. The pattern was:

```python
_URL_CALL = re.compile(r"url\(\s*(['\"]?)([^'\")\s]*)\1\s*\)", re.IGNORECASE)
```

The target class `[^'")\s]*` **includes `(`**. On an input like `url(` + `url(!`×N (no `)`, no quote, no whitespace):

- at every `url(` start the greedy class scans to end-of-input, then backtracks one char at a time hunting for the required closing `)` that never appears — O(n) wasted work per start position;
- there are O(n) `url(` start positions ⇒ **O(n²)** overall.

Measured on the current pattern (`list(_URL_CALL.finditer(...))`): ~18 ms → ~295 ms → **~4.06 s** for N = 500 → 2 000 → 8 000 (super-linear, unbounded).

> Reachability note: this branch is currently only entered via `encode_css_safe(..., allow_url=True)` — all registry entries use `allow_url=False`, and the admin save path additionally caps value length at `MAX_TOKEN_VALUE_LENGTH = 256` — so production exposure today is limited. The latent regex is fixed regardless (CodeQL flags the user-value → regex data flow).

## The fix

```python
_URL_CALL = re.compile(r"url\(\s*(['\"]?)([^'\")(\s]*+)\1\s*\)", re.IGNORECASE)
```

Two changes to the target group:

1. **Exclude `(` from the class** (`[^'")(\s]`) — mirrors the CSS *url-token* grammar (an unquoted `url()` value cannot contain an unescaped `(`), so the scan stops at the next `(` instead of running to end-of-input. This is what restores **linear** time.
2. **Possessive quantifier** (`*+`) — the class's followers (`\1`, `\s*`, `\)`) are all disjoint from it, so backtracking into the class can never help a match; `*+` forbids that backtracking outright and guarantees no blow-up.

Why "just make it atomic/possessive" is **not** sufficient (I measured it): keeping `(` in the class and adding only `*+`/an atomic group removes the *backtracking* but leaves an O(n²) *forward* scan (each `url(` still scans to EOF) — still **~18 s at N = 32 000**. Only excluding `(` gives linear time.

After the fix: **~87 ms at N = 512 000** (linear).

## Behavior preservation (conservative for a payments app)

- **Randomized differential** over **200 000** `url(`-prefixed inputs, old vs new pattern: the **only** classification differences (3 398) involve an unescaped `(` in the url target; **zero** non-`(` differences. Those `(`-bearing values are invalid CSS (and the spec-valid *quoted* form was already rejected by the previous pattern too), so this is a strict tightening on already-invalid input — **every legitimate (spec-valid) value classifies identically.**
- The shared **parity corpus** (`test-fixtures/theme-token-corpus.json`) has **no** `url()` cases, so client/server parity tests are unaffected.
- The **frontend mirror** `frontend/src/app/core/theme/css-safe-encode.ts` gets the identical class change to keep the documented "accepted on client ⇒ accepted on save" contract true. JS has no possessive quantifier, but excluding `(` alone is linear and **match-equivalent** to the possessive form (verified: 0 mismatches across the 200 000 inputs).

## Tests / evidence

- Added `test_encode_css_safe_url_matching_is_linear_not_redos` (100k-char pathological input resolves < 1 s and still hard-rejects) and `test_encode_css_safe_url_rejects_unescaped_paren_target`.
- `pytest backend/tests/test_theme_validation.py` → **77 passed** (0.96 s).
- `theme_validation.py` coverage: **100%** line + branch (134 stmts / 48 branches), matching the repo's 100% gate.
- `ruff check` and `ruff format --check` on the changed Python files: clean.
- Target runtime is Python 3.12 (Dockerfile + CI), which supports possessive quantifiers / atomic groups (3.11+).

> I could not run the frontend toolchain (vitest/eslint) in this environment. The TS change is a one-line regex-class edit that breaks no existing `css-safe-encode.spec.ts` case (none use a `(`-in-url target) and is coverage-neutral; please let the frontend CI confirm. If preferred, the frontend hunk can be dropped and landed separately — the backend hunk is self-contained.

Resolves CodeQL alert #1093 (`py/polynomial-redos`).

https://claude.ai/code/session_01AMvR2PHoEEGaxgaciH5nFh
